### PR TITLE
Improve name collision avoidance

### DIFF
--- a/src/meta.ts
+++ b/src/meta.ts
@@ -171,16 +171,16 @@ export class Parser {
                 if (log) {
                     log("GRAM");
                 }
-                let header: Nullable<Nullable<HDR>>;
-                let rules: Nullable<RULEDEF[]>;
-                let res: Nullable<GRAM> = null;
+                let $scope$header: Nullable<Nullable<HDR>>;
+                let $scope$rules: Nullable<RULEDEF[]>;
+                let $$res: Nullable<GRAM> = null;
                 if (true
-                    && ((header = this.matchHDR($$dpth + 1, cr)) || true)
-                    && (rules = this.loop<RULEDEF>(() => this.matchRULEDEF($$dpth + 1, cr), false)) !== null
+                    && (($scope$header = this.matchHDR($$dpth + 1, cr)) || true)
+                    && ($scope$rules = this.loop<RULEDEF>(() => this.matchRULEDEF($$dpth + 1, cr), false)) !== null
                 ) {
-                    res = {kind: ASTKinds.GRAM, header, rules};
+                    $$res = {kind: ASTKinds.GRAM, header: $scope$header, rules: $scope$rules};
                 }
-                return res;
+                return $$res;
             }, cr)();
     }
     public matchHDR($$dpth: number, cr?: ContextRecorder): Nullable<HDR> {
@@ -189,16 +189,16 @@ export class Parser {
                 if (log) {
                     log("HDR");
                 }
-                let content: Nullable<string>;
-                let res: Nullable<HDR> = null;
+                let $scope$content: Nullable<string>;
+                let $$res: Nullable<HDR> = null;
                 if (true
                     && this.regexAccept(String.raw`(?:---)`, $$dpth + 1, cr) !== null
-                    && (content = this.regexAccept(String.raw`(?:((?!---)(.|\n))*)`, $$dpth + 1, cr)) !== null
+                    && ($scope$content = this.regexAccept(String.raw`(?:((?!---)(.|\n))*)`, $$dpth + 1, cr)) !== null
                     && this.regexAccept(String.raw`(?:---)`, $$dpth + 1, cr) !== null
                 ) {
-                    res = {kind: ASTKinds.HDR, content};
+                    $$res = {kind: ASTKinds.HDR, content: $scope$content};
                 }
-                return res;
+                return $$res;
             }, cr)();
     }
     public matchRULEDEF($$dpth: number, cr?: ContextRecorder): Nullable<RULEDEF> {
@@ -207,21 +207,21 @@ export class Parser {
                 if (log) {
                     log("RULEDEF");
                 }
-                let name: Nullable<NAME>;
-                let rule: Nullable<RULE>;
-                let res: Nullable<RULEDEF> = null;
+                let $scope$name: Nullable<NAME>;
+                let $scope$rule: Nullable<RULE>;
+                let $$res: Nullable<RULEDEF> = null;
                 if (true
                     && this.match_($$dpth + 1, cr) !== null
-                    && (name = this.matchNAME($$dpth + 1, cr)) !== null
+                    && ($scope$name = this.matchNAME($$dpth + 1, cr)) !== null
                     && this.match_($$dpth + 1, cr) !== null
                     && this.regexAccept(String.raw`(?::=)`, $$dpth + 1, cr) !== null
                     && this.match_($$dpth + 1, cr) !== null
-                    && (rule = this.matchRULE($$dpth + 1, cr)) !== null
+                    && ($scope$rule = this.matchRULE($$dpth + 1, cr)) !== null
                     && this.match_($$dpth + 1, cr) !== null
                 ) {
-                    res = {kind: ASTKinds.RULEDEF, name, rule};
+                    $$res = {kind: ASTKinds.RULEDEF, name: $scope$name, rule: $scope$rule};
                 }
-                return res;
+                return $$res;
             }, cr)();
     }
     public matchRULE($$dpth: number, cr?: ContextRecorder): Nullable<RULE> {
@@ -230,16 +230,16 @@ export class Parser {
                 if (log) {
                     log("RULE");
                 }
-                let head: Nullable<ALT>;
-                let tail: Nullable<RULE_$0[]>;
-                let res: Nullable<RULE> = null;
+                let $scope$head: Nullable<ALT>;
+                let $scope$tail: Nullable<RULE_$0[]>;
+                let $$res: Nullable<RULE> = null;
                 if (true
-                    && (head = this.matchALT($$dpth + 1, cr)) !== null
-                    && (tail = this.loop<RULE_$0>(() => this.matchRULE_$0($$dpth + 1, cr), true)) !== null
+                    && ($scope$head = this.matchALT($$dpth + 1, cr)) !== null
+                    && ($scope$tail = this.loop<RULE_$0>(() => this.matchRULE_$0($$dpth + 1, cr), true)) !== null
                 ) {
-                    res = new RULE(head, tail);
+                    $$res = new RULE($scope$head, $scope$tail);
                 }
-                return res;
+                return $$res;
             }, cr)();
     }
     public matchRULE_$0($$dpth: number, cr?: ContextRecorder): Nullable<RULE_$0> {
@@ -248,17 +248,17 @@ export class Parser {
                 if (log) {
                     log("RULE_$0");
                 }
-                let alt: Nullable<ALT>;
-                let res: Nullable<RULE_$0> = null;
+                let $scope$alt: Nullable<ALT>;
+                let $$res: Nullable<RULE_$0> = null;
                 if (true
                     && this.match_($$dpth + 1, cr) !== null
                     && this.regexAccept(String.raw`(?:\|)`, $$dpth + 1, cr) !== null
                     && this.match_($$dpth + 1, cr) !== null
-                    && (alt = this.matchALT($$dpth + 1, cr)) !== null
+                    && ($scope$alt = this.matchALT($$dpth + 1, cr)) !== null
                 ) {
-                    res = {kind: ASTKinds.RULE_$0, alt};
+                    $$res = {kind: ASTKinds.RULE_$0, alt: $scope$alt};
                 }
-                return res;
+                return $$res;
             }, cr)();
     }
     public matchALT($$dpth: number, cr?: ContextRecorder): Nullable<ALT> {
@@ -267,16 +267,16 @@ export class Parser {
                 if (log) {
                     log("ALT");
                 }
-                let matches: Nullable<MATCHSPEC[]>;
-                let attrs: Nullable<ATTR[]>;
-                let res: Nullable<ALT> = null;
+                let $scope$matches: Nullable<MATCHSPEC[]>;
+                let $scope$attrs: Nullable<ATTR[]>;
+                let $$res: Nullable<ALT> = null;
                 if (true
-                    && (matches = this.loop<MATCHSPEC>(() => this.matchMATCHSPEC($$dpth + 1, cr), false)) !== null
-                    && (attrs = this.loop<ATTR>(() => this.matchATTR($$dpth + 1, cr), true)) !== null
+                    && ($scope$matches = this.loop<MATCHSPEC>(() => this.matchMATCHSPEC($$dpth + 1, cr), false)) !== null
+                    && ($scope$attrs = this.loop<ATTR>(() => this.matchATTR($$dpth + 1, cr), true)) !== null
                 ) {
-                    res = {kind: ASTKinds.ALT, matches, attrs};
+                    $$res = {kind: ASTKinds.ALT, matches: $scope$matches, attrs: $scope$attrs};
                 }
-                return res;
+                return $$res;
             }, cr)();
     }
     public matchMATCHSPEC($$dpth: number, cr?: ContextRecorder): Nullable<MATCHSPEC> {
@@ -285,17 +285,17 @@ export class Parser {
                 if (log) {
                     log("MATCHSPEC");
                 }
-                let named: Nullable<Nullable<MATCHSPEC_$0>>;
-                let rule: Nullable<MATCH>;
-                let res: Nullable<MATCHSPEC> = null;
+                let $scope$named: Nullable<Nullable<MATCHSPEC_$0>>;
+                let $scope$rule: Nullable<MATCH>;
+                let $$res: Nullable<MATCHSPEC> = null;
                 if (true
                     && this.match_($$dpth + 1, cr) !== null
-                    && ((named = this.matchMATCHSPEC_$0($$dpth + 1, cr)) || true)
-                    && (rule = this.matchMATCH($$dpth + 1, cr)) !== null
+                    && (($scope$named = this.matchMATCHSPEC_$0($$dpth + 1, cr)) || true)
+                    && ($scope$rule = this.matchMATCH($$dpth + 1, cr)) !== null
                 ) {
-                    res = {kind: ASTKinds.MATCHSPEC, named, rule};
+                    $$res = {kind: ASTKinds.MATCHSPEC, named: $scope$named, rule: $scope$rule};
                 }
-                return res;
+                return $$res;
             }, cr)();
     }
     public matchMATCHSPEC_$0($$dpth: number, cr?: ContextRecorder): Nullable<MATCHSPEC_$0> {
@@ -304,17 +304,17 @@ export class Parser {
                 if (log) {
                     log("MATCHSPEC_$0");
                 }
-                let name: Nullable<NAME>;
-                let res: Nullable<MATCHSPEC_$0> = null;
+                let $scope$name: Nullable<NAME>;
+                let $$res: Nullable<MATCHSPEC_$0> = null;
                 if (true
-                    && (name = this.matchNAME($$dpth + 1, cr)) !== null
+                    && ($scope$name = this.matchNAME($$dpth + 1, cr)) !== null
                     && this.match_($$dpth + 1, cr) !== null
                     && this.regexAccept(String.raw`(?:=)`, $$dpth + 1, cr) !== null
                     && this.match_($$dpth + 1, cr) !== null
                 ) {
-                    res = {kind: ASTKinds.MATCHSPEC_$0, name};
+                    $$res = {kind: ASTKinds.MATCHSPEC_$0, name: $scope$name};
                 }
-                return res;
+                return $$res;
             }, cr)();
     }
     public matchMATCH($$dpth: number, cr?: ContextRecorder): Nullable<MATCH> {
@@ -335,14 +335,14 @@ export class Parser {
                 if (log) {
                     log("SPECIAL");
                 }
-                let op: Nullable<string>;
-                let res: Nullable<SPECIAL> = null;
+                let $scope$op: Nullable<string>;
+                let $$res: Nullable<SPECIAL> = null;
                 if (true
-                    && (op = this.regexAccept(String.raw`(?:@)`, $$dpth + 1, cr)) !== null
+                    && ($scope$op = this.regexAccept(String.raw`(?:@)`, $$dpth + 1, cr)) !== null
                 ) {
-                    res = {kind: ASTKinds.SPECIAL, op};
+                    $$res = {kind: ASTKinds.SPECIAL, op: $scope$op};
                 }
-                return res;
+                return $$res;
             }, cr)();
     }
     public matchPOSTOP($$dpth: number, cr?: ContextRecorder): Nullable<POSTOP> {
@@ -351,16 +351,16 @@ export class Parser {
                 if (log) {
                     log("POSTOP");
                 }
-                let pre: Nullable<PREOP>;
-                let op: Nullable<Nullable<string>>;
-                let res: Nullable<POSTOP> = null;
+                let $scope$pre: Nullable<PREOP>;
+                let $scope$op: Nullable<Nullable<string>>;
+                let $$res: Nullable<POSTOP> = null;
                 if (true
-                    && (pre = this.matchPREOP($$dpth + 1, cr)) !== null
-                    && ((op = this.regexAccept(String.raw`(?:\+|\*|\?)`, $$dpth + 1, cr)) || true)
+                    && ($scope$pre = this.matchPREOP($$dpth + 1, cr)) !== null
+                    && (($scope$op = this.regexAccept(String.raw`(?:\+|\*|\?)`, $$dpth + 1, cr)) || true)
                 ) {
-                    res = new POSTOP(pre, op);
+                    $$res = new POSTOP($scope$pre, $scope$op);
                 }
-                return res;
+                return $$res;
             }, cr)();
     }
     public matchPREOP($$dpth: number, cr?: ContextRecorder): Nullable<PREOP> {
@@ -369,16 +369,16 @@ export class Parser {
                 if (log) {
                     log("PREOP");
                 }
-                let op: Nullable<Nullable<string>>;
-                let at: Nullable<ATOM>;
-                let res: Nullable<PREOP> = null;
+                let $scope$op: Nullable<Nullable<string>>;
+                let $scope$at: Nullable<ATOM>;
+                let $$res: Nullable<PREOP> = null;
                 if (true
-                    && ((op = this.regexAccept(String.raw`(?:\&|!)`, $$dpth + 1, cr)) || true)
-                    && (at = this.matchATOM($$dpth + 1, cr)) !== null
+                    && (($scope$op = this.regexAccept(String.raw`(?:\&|!)`, $$dpth + 1, cr)) || true)
+                    && ($scope$at = this.matchATOM($$dpth + 1, cr)) !== null
                 ) {
-                    res = {kind: ASTKinds.PREOP, op, at};
+                    $$res = {kind: ASTKinds.PREOP, op: $scope$op, at: $scope$at};
                 }
-                return res;
+                return $$res;
             }, cr)();
     }
     public matchATOM($$dpth: number, cr?: ContextRecorder): Nullable<ATOM> {
@@ -394,15 +394,15 @@ export class Parser {
                 if (log) {
                     log("ATOM_1");
                 }
-                let name: Nullable<NAME>;
-                let res: Nullable<ATOM_1> = null;
+                let $scope$name: Nullable<NAME>;
+                let $$res: Nullable<ATOM_1> = null;
                 if (true
-                    && (name = this.matchNAME($$dpth + 1, cr)) !== null
+                    && ($scope$name = this.matchNAME($$dpth + 1, cr)) !== null
                     && this.negate(() => this.regexAccept(String.raw`(?:\s*:=)`, $$dpth + 1, cr)) !== null
                 ) {
-                    res = {kind: ASTKinds.ATOM_1, name};
+                    $$res = {kind: ASTKinds.ATOM_1, name: $scope$name};
                 }
-                return res;
+                return $$res;
             }, cr)();
     }
     public matchATOM_2($$dpth: number, cr?: ContextRecorder): Nullable<ATOM_2> {
@@ -411,14 +411,14 @@ export class Parser {
                 if (log) {
                     log("ATOM_2");
                 }
-                let match: Nullable<STRLIT>;
-                let res: Nullable<ATOM_2> = null;
+                let $scope$match: Nullable<STRLIT>;
+                let $$res: Nullable<ATOM_2> = null;
                 if (true
-                    && (match = this.matchSTRLIT($$dpth + 1, cr)) !== null
+                    && ($scope$match = this.matchSTRLIT($$dpth + 1, cr)) !== null
                 ) {
-                    res = {kind: ASTKinds.ATOM_2, match};
+                    $$res = {kind: ASTKinds.ATOM_2, match: $scope$match};
                 }
-                return res;
+                return $$res;
             }, cr)();
     }
     public matchATOM_3($$dpth: number, cr?: ContextRecorder): Nullable<ATOM_3> {
@@ -427,18 +427,18 @@ export class Parser {
                 if (log) {
                     log("ATOM_3");
                 }
-                let sub: Nullable<RULE>;
-                let res: Nullable<ATOM_3> = null;
+                let $scope$sub: Nullable<RULE>;
+                let $$res: Nullable<ATOM_3> = null;
                 if (true
                     && this.regexAccept(String.raw`(?:{)`, $$dpth + 1, cr) !== null
                     && this.match_($$dpth + 1, cr) !== null
-                    && (sub = this.matchRULE($$dpth + 1, cr)) !== null
+                    && ($scope$sub = this.matchRULE($$dpth + 1, cr)) !== null
                     && this.match_($$dpth + 1, cr) !== null
                     && this.regexAccept(String.raw`(?:})`, $$dpth + 1, cr) !== null
                 ) {
-                    res = {kind: ASTKinds.ATOM_3, sub};
+                    $$res = {kind: ASTKinds.ATOM_3, sub: $scope$sub};
                 }
-                return res;
+                return $$res;
             }, cr)();
     }
     public matchATTR($$dpth: number, cr?: ContextRecorder): Nullable<ATTR> {
@@ -447,26 +447,26 @@ export class Parser {
                 if (log) {
                     log("ATTR");
                 }
-                let name: Nullable<NAME>;
-                let type: Nullable<string>;
-                let action: Nullable<string>;
-                let res: Nullable<ATTR> = null;
+                let $scope$name: Nullable<NAME>;
+                let $scope$type: Nullable<string>;
+                let $scope$action: Nullable<string>;
+                let $$res: Nullable<ATTR> = null;
                 if (true
                     && this.match_($$dpth + 1, cr) !== null
                     && this.regexAccept(String.raw`(?:\.)`, $$dpth + 1, cr) !== null
-                    && (name = this.matchNAME($$dpth + 1, cr)) !== null
+                    && ($scope$name = this.matchNAME($$dpth + 1, cr)) !== null
                     && this.match_($$dpth + 1, cr) !== null
                     && this.regexAccept(String.raw`(?:=)`, $$dpth + 1, cr) !== null
                     && this.match_($$dpth + 1, cr) !== null
-                    && (type = this.regexAccept(String.raw`(?:[^\s\{]+)`, $$dpth + 1, cr)) !== null
+                    && ($scope$type = this.regexAccept(String.raw`(?:[^\s\{]+)`, $$dpth + 1, cr)) !== null
                     && this.match_($$dpth + 1, cr) !== null
                     && this.regexAccept(String.raw`(?:\{)`, $$dpth + 1, cr) !== null
-                    && (action = this.regexAccept(String.raw`(?:([^\{\}\\]|(\\.))*)`, $$dpth + 1, cr)) !== null
+                    && ($scope$action = this.regexAccept(String.raw`(?:([^\{\}\\]|(\\.))*)`, $$dpth + 1, cr)) !== null
                     && this.regexAccept(String.raw`(?:\})`, $$dpth + 1, cr) !== null
                 ) {
-                    res = {kind: ASTKinds.ATTR, name, type, action};
+                    $$res = {kind: ASTKinds.ATTR, name: $scope$name, type: $scope$type, action: $scope$action};
                 }
-                return res;
+                return $$res;
             }, cr)();
     }
     public matchNAME($$dpth: number, cr?: ContextRecorder): Nullable<NAME> {
@@ -478,18 +478,18 @@ export class Parser {
                 if (log) {
                     log("STRLIT");
                 }
-                let start: Nullable<PosInfo>;
-                let val: Nullable<string>;
-                let res: Nullable<STRLIT> = null;
+                let $scope$start: Nullable<PosInfo>;
+                let $scope$val: Nullable<string>;
+                let $$res: Nullable<STRLIT> = null;
                 if (true
-                    && (start = this.mark()) !== null
+                    && ($scope$start = this.mark()) !== null
                     && this.regexAccept(String.raw`(?:\')`, $$dpth + 1, cr) !== null
-                    && (val = this.regexAccept(String.raw`(?:([^\'\\]|(\\.))*)`, $$dpth + 1, cr)) !== null
+                    && ($scope$val = this.regexAccept(String.raw`(?:([^\'\\]|(\\.))*)`, $$dpth + 1, cr)) !== null
                     && this.regexAccept(String.raw`(?:\')`, $$dpth + 1, cr) !== null
                 ) {
-                    res = {kind: ASTKinds.STRLIT, start, val};
+                    $$res = {kind: ASTKinds.STRLIT, start: $scope$start, val: $scope$val};
                 }
-                return res;
+                return $$res;
             }, cr)();
     }
     public match_($$dpth: number, cr?: ContextRecorder): Nullable<_> {

--- a/src/test/calctest/parser.ts
+++ b/src/test/calctest/parser.ts
@@ -127,140 +127,140 @@ export class Parser {
     public finished(): boolean {
         return this.pos.overallPos === this.input.length;
     }
-    public matchSUM($$dpth: number, cr?: ContextRecorder): Nullable<SUM> {
+    public matchSUM($$dpth: number, $$cr?: ContextRecorder): Nullable<SUM> {
         return this.runner<SUM>($$dpth,
             (log) => {
                 if (log) {
                     log("SUM");
                 }
-                let head: Nullable<FAC>;
-                let tail: Nullable<SUM_$0[]>;
-                let res: Nullable<SUM> = null;
+                let $scope$head: Nullable<FAC>;
+                let $scope$tail: Nullable<SUM_$0[]>;
+                let $$res: Nullable<SUM> = null;
                 if (true
-                    && (head = this.matchFAC($$dpth + 1, cr)) !== null
-                    && (tail = this.loop<SUM_$0>(() => this.matchSUM_$0($$dpth + 1, cr), true)) !== null
+                    && ($scope$head = this.matchFAC($$dpth + 1, $$cr)) !== null
+                    && ($scope$tail = this.loop<SUM_$0>(() => this.matchSUM_$0($$dpth + 1, $$cr), true)) !== null
                 ) {
-                    res = new SUM(head, tail);
+                    $$res = new SUM($scope$head, $scope$tail);
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchSUM_$0($$dpth: number, cr?: ContextRecorder): Nullable<SUM_$0> {
+    public matchSUM_$0($$dpth: number, $$cr?: ContextRecorder): Nullable<SUM_$0> {
         return this.runner<SUM_$0>($$dpth,
             (log) => {
                 if (log) {
                     log("SUM_$0");
                 }
-                let op: Nullable<string>;
-                let sm: Nullable<FAC>;
-                let res: Nullable<SUM_$0> = null;
+                let $scope$op: Nullable<string>;
+                let $scope$sm: Nullable<FAC>;
+                let $$res: Nullable<SUM_$0> = null;
                 if (true
-                    && (op = this.regexAccept(String.raw`(?:\+|-)`, $$dpth + 1, cr)) !== null
-                    && (sm = this.matchFAC($$dpth + 1, cr)) !== null
+                    && ($scope$op = this.regexAccept(String.raw`(?:\+|-)`, $$dpth + 1, $$cr)) !== null
+                    && ($scope$sm = this.matchFAC($$dpth + 1, $$cr)) !== null
                 ) {
-                    res = {kind: ASTKinds.SUM_$0, op, sm};
+                    $$res = {kind: ASTKinds.SUM_$0, op: $scope$op, sm: $scope$sm};
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchFAC($$dpth: number, cr?: ContextRecorder): Nullable<FAC> {
+    public matchFAC($$dpth: number, $$cr?: ContextRecorder): Nullable<FAC> {
         return this.runner<FAC>($$dpth,
             (log) => {
                 if (log) {
                     log("FAC");
                 }
-                let head: Nullable<ATOM>;
-                let tail: Nullable<FAC_$0[]>;
-                let res: Nullable<FAC> = null;
+                let $scope$head: Nullable<ATOM>;
+                let $scope$tail: Nullable<FAC_$0[]>;
+                let $$res: Nullable<FAC> = null;
                 if (true
-                    && (head = this.matchATOM($$dpth + 1, cr)) !== null
-                    && (tail = this.loop<FAC_$0>(() => this.matchFAC_$0($$dpth + 1, cr), true)) !== null
+                    && ($scope$head = this.matchATOM($$dpth + 1, $$cr)) !== null
+                    && ($scope$tail = this.loop<FAC_$0>(() => this.matchFAC_$0($$dpth + 1, $$cr), true)) !== null
                 ) {
-                    res = new FAC(head, tail);
+                    $$res = new FAC($scope$head, $scope$tail);
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchFAC_$0($$dpth: number, cr?: ContextRecorder): Nullable<FAC_$0> {
+    public matchFAC_$0($$dpth: number, $$cr?: ContextRecorder): Nullable<FAC_$0> {
         return this.runner<FAC_$0>($$dpth,
             (log) => {
                 if (log) {
                     log("FAC_$0");
                 }
-                let op: Nullable<string>;
-                let sm: Nullable<ATOM>;
-                let res: Nullable<FAC_$0> = null;
+                let $scope$op: Nullable<string>;
+                let $scope$sm: Nullable<ATOM>;
+                let $$res: Nullable<FAC_$0> = null;
                 if (true
-                    && (op = this.regexAccept(String.raw`(?:\*|/)`, $$dpth + 1, cr)) !== null
-                    && (sm = this.matchATOM($$dpth + 1, cr)) !== null
+                    && ($scope$op = this.regexAccept(String.raw`(?:\*|/)`, $$dpth + 1, $$cr)) !== null
+                    && ($scope$sm = this.matchATOM($$dpth + 1, $$cr)) !== null
                 ) {
-                    res = {kind: ASTKinds.FAC_$0, op, sm};
+                    $$res = {kind: ASTKinds.FAC_$0, op: $scope$op, sm: $scope$sm};
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchATOM($$dpth: number, cr?: ContextRecorder): Nullable<ATOM> {
+    public matchATOM($$dpth: number, $$cr?: ContextRecorder): Nullable<ATOM> {
         return this.choice<ATOM>([
-            () => this.matchATOM_1($$dpth + 1, cr),
-            () => this.matchATOM_2($$dpth + 1, cr),
+            () => this.matchATOM_1($$dpth + 1, $$cr),
+            () => this.matchATOM_2($$dpth + 1, $$cr),
         ]);
     }
-    public matchATOM_1($$dpth: number, cr?: ContextRecorder): Nullable<ATOM_1> {
+    public matchATOM_1($$dpth: number, $$cr?: ContextRecorder): Nullable<ATOM_1> {
         return this.runner<ATOM_1>($$dpth,
             (log) => {
                 if (log) {
                     log("ATOM_1");
                 }
-                let val: Nullable<INT>;
-                let res: Nullable<ATOM_1> = null;
+                let $scope$val: Nullable<INT>;
+                let $$res: Nullable<ATOM_1> = null;
                 if (true
-                    && this.match_($$dpth + 1, cr) !== null
-                    && (val = this.matchINT($$dpth + 1, cr)) !== null
-                    && this.match_($$dpth + 1, cr) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && ($scope$val = this.matchINT($$dpth + 1, $$cr)) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
                 ) {
-                    res = new ATOM_1(val);
+                    $$res = new ATOM_1($scope$val);
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchATOM_2($$dpth: number, cr?: ContextRecorder): Nullable<ATOM_2> {
+    public matchATOM_2($$dpth: number, $$cr?: ContextRecorder): Nullable<ATOM_2> {
         return this.runner<ATOM_2>($$dpth,
             (log) => {
                 if (log) {
                     log("ATOM_2");
                 }
-                let val: Nullable<SUM>;
-                let res: Nullable<ATOM_2> = null;
+                let $scope$val: Nullable<SUM>;
+                let $$res: Nullable<ATOM_2> = null;
                 if (true
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.regexAccept(String.raw`(?:\()`, $$dpth + 1, cr) !== null
-                    && (val = this.matchSUM($$dpth + 1, cr)) !== null
-                    && this.regexAccept(String.raw`(?:\))`, $$dpth + 1, cr) !== null
-                    && this.match_($$dpth + 1, cr) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.regexAccept(String.raw`(?:\()`, $$dpth + 1, $$cr) !== null
+                    && ($scope$val = this.matchSUM($$dpth + 1, $$cr)) !== null
+                    && this.regexAccept(String.raw`(?:\))`, $$dpth + 1, $$cr) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
                 ) {
-                    res = new ATOM_2(val);
+                    $$res = new ATOM_2($scope$val);
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchINT($$dpth: number, cr?: ContextRecorder): Nullable<INT> {
+    public matchINT($$dpth: number, $$cr?: ContextRecorder): Nullable<INT> {
         return this.runner<INT>($$dpth,
             (log) => {
                 if (log) {
                     log("INT");
                 }
-                let val: Nullable<string>;
-                let res: Nullable<INT> = null;
+                let $scope$val: Nullable<string>;
+                let $$res: Nullable<INT> = null;
                 if (true
-                    && (val = this.regexAccept(String.raw`(?:[0-9]+)`, $$dpth + 1, cr)) !== null
+                    && ($scope$val = this.regexAccept(String.raw`(?:[0-9]+)`, $$dpth + 1, $$cr)) !== null
                 ) {
-                    res = new INT(val);
+                    $$res = new INT($scope$val);
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public match_($$dpth: number, cr?: ContextRecorder): Nullable<_> {
-        return this.regexAccept(String.raw`(?:\s*)`, $$dpth + 1, cr);
+    public match_($$dpth: number, $$cr?: ContextRecorder): Nullable<_> {
+        return this.regexAccept(String.raw`(?:\s*)`, $$dpth + 1, $$cr);
     }
     public test(): boolean {
         const mrk = this.mark();

--- a/src/test/eof_test/parser.ts
+++ b/src/test/eof_test/parser.ts
@@ -29,8 +29,8 @@ export class Parser {
     public finished(): boolean {
         return this.pos.overallPos === this.input.length;
     }
-    public matchRULE($$dpth: number, cr?: ContextRecorder): Nullable<RULE> {
-        return this.regexAccept(String.raw`(?:abcde)`, $$dpth + 1, cr);
+    public matchRULE($$dpth: number, $$cr?: ContextRecorder): Nullable<RULE> {
+        return this.regexAccept(String.raw`(?:abcde)`, $$dpth + 1, $$cr);
     }
     public test(): boolean {
         const mrk = this.mark();

--- a/src/test/gen.test.ts
+++ b/src/test/gen.test.ts
@@ -143,42 +143,42 @@ test("match type/rule test", () => {
         {
             match: "ruleReference",
             expType: "ruleReference",
-            expRule: "this.matchruleReference($$dpth + 1, cr)"
+            expRule: "this.matchruleReference($$dpth + 1, $$cr)"
         },
         {
             match: "ruleReference*",
             expType: "ruleReference[]",
-            expRule: "this.loop<ruleReference>(() => this.matchruleReference($$dpth + 1, cr), true)"
+            expRule: "this.loop<ruleReference>(() => this.matchruleReference($$dpth + 1, $$cr), true)"
         },
         {
             match: "ruleReference+",
             expType: "ruleReference[]",
-            expRule: "this.loop<ruleReference>(() => this.matchruleReference($$dpth + 1, cr), false)"
+            expRule: "this.loop<ruleReference>(() => this.matchruleReference($$dpth + 1, $$cr), false)"
         },
         {
             match: "ruleReference?",
             expType: "Nullable<ruleReference>",
-            expRule: "this.matchruleReference($$dpth + 1, cr)"
+            expRule: "this.matchruleReference($$dpth + 1, $$cr)"
         },
         {
             match: "!ruleReference",
             expType: "boolean",
-            expRule: "this.negate(() => this.matchruleReference($$dpth + 1, cr))"
+            expRule: "this.negate(() => this.matchruleReference($$dpth + 1, $$cr))"
         },
         {
             match: "'regex'",
             expType: "string",
-            expRule: "this.regexAccept(String.raw`(?:regex)`, $$dpth + 1, cr)"
+            expRule: "this.regexAccept(String.raw`(?:regex)`, $$dpth + 1, $$cr)"
         },
         {
             match: "'regex'+",
             expType: "string[]",
-            expRule: "this.loop<string>(() => this.regexAccept(String.raw`(?:regex)`, $$dpth + 1, cr), false)"
+            expRule: "this.loop<string>(() => this.regexAccept(String.raw`(?:regex)`, $$dpth + 1, $$cr), false)"
         },
         {
             match: "&'regex'",
             expType: "string",
-            expRule: "this.noConsume<string>(() => this.regexAccept(String.raw`(?:regex)`, $$dpth + 1, cr))"
+            expRule: "this.noConsume<string>(() => this.regexAccept(String.raw`(?:regex)`, $$dpth + 1, $$cr))"
         },
         {
             match: "@",
@@ -204,7 +204,7 @@ test("match type/rule test", () => {
 test("subrule type/rule test", () => {
     const inp = "rule := 'has' { subrule }";
     const expectedType = "rule_$0";
-    const expectedRule = "this.matchrule_$0($$dpth + 1, cr)";
+    const expectedRule = "this.matchrule_$0($$dpth + 1, $$cr)";
 
     const res = parse(inp);
     expect(res.err).toBeNull();

--- a/src/test/id_test/grammar.peg
+++ b/src/test/id_test/grammar.peg
@@ -4,3 +4,9 @@ lowercase := 'a'
 UPPERCASE := 'b'
 _start_hypen_ := 'c'
 numbers1ab234 := 'd'
+
+// Check for namespace collision
+
+rule := rule=rule .a = number { return 0; }
+rule2 := res='a'
+rule3 := cr='b'

--- a/src/test/id_test/parser.ts
+++ b/src/test/id_test/parser.ts
@@ -5,6 +5,10 @@
 * UPPERCASE := 'b'
 * _start_hypen_ := 'c'
 * numbers1ab234 := 'd'
+* // Check for namespace collision
+* rule := rule=rule .a = number { return 0; }
+* rule2 := res='a'
+* rule3 := cr='b'
 */
 type Nullable<T> = T | null;
 type $$RuleType<T> = (log?: (msg: string) => void) => Nullable<T>;
@@ -19,11 +23,33 @@ export enum ASTKinds {
     UPPERCASE,
     _start_hypen_,
     numbers1ab234,
+    rule,
+    rule2,
+    rule3,
 }
 export type lowercase = string;
 export type UPPERCASE = string;
 export type _start_hypen_ = string;
 export type numbers1ab234 = string;
+export class rule {
+    public kind: ASTKinds.rule = ASTKinds.rule;
+    public rule: rule;
+    public a: number;
+    constructor(rule: rule){
+        this.rule = rule;
+        this.a = (() => {
+        return 0;
+        })();
+    }
+}
+export interface rule2 {
+    kind: ASTKinds.rule2;
+    res: string;
+}
+export interface rule3 {
+    kind: ASTKinds.rule3;
+    cr: string;
+}
 export class Parser {
     private readonly input: string;
     private pos: PosInfo;
@@ -38,17 +64,65 @@ export class Parser {
     public finished(): boolean {
         return this.pos.overallPos === this.input.length;
     }
-    public matchlowercase($$dpth: number, cr?: ContextRecorder): Nullable<lowercase> {
-        return this.regexAccept(String.raw`(?:a)`, $$dpth + 1, cr);
+    public matchlowercase($$dpth: number, $$cr?: ContextRecorder): Nullable<lowercase> {
+        return this.regexAccept(String.raw`(?:a)`, $$dpth + 1, $$cr);
     }
-    public matchUPPERCASE($$dpth: number, cr?: ContextRecorder): Nullable<UPPERCASE> {
-        return this.regexAccept(String.raw`(?:b)`, $$dpth + 1, cr);
+    public matchUPPERCASE($$dpth: number, $$cr?: ContextRecorder): Nullable<UPPERCASE> {
+        return this.regexAccept(String.raw`(?:b)`, $$dpth + 1, $$cr);
     }
-    public match_start_hypen_($$dpth: number, cr?: ContextRecorder): Nullable<_start_hypen_> {
-        return this.regexAccept(String.raw`(?:c)`, $$dpth + 1, cr);
+    public match_start_hypen_($$dpth: number, $$cr?: ContextRecorder): Nullable<_start_hypen_> {
+        return this.regexAccept(String.raw`(?:c)`, $$dpth + 1, $$cr);
     }
-    public matchnumbers1ab234($$dpth: number, cr?: ContextRecorder): Nullable<numbers1ab234> {
-        return this.regexAccept(String.raw`(?:d)`, $$dpth + 1, cr);
+    public matchnumbers1ab234($$dpth: number, $$cr?: ContextRecorder): Nullable<numbers1ab234> {
+        return this.regexAccept(String.raw`(?:d)`, $$dpth + 1, $$cr);
+    }
+    public matchrule($$dpth: number, $$cr?: ContextRecorder): Nullable<rule> {
+        return this.runner<rule>($$dpth,
+            (log) => {
+                if (log) {
+                    log("rule");
+                }
+                let $scope$rule: Nullable<rule>;
+                let $$res: Nullable<rule> = null;
+                if (true
+                    && ($scope$rule = this.matchrule($$dpth + 1, $$cr)) !== null
+                ) {
+                    $$res = new rule($scope$rule);
+                }
+                return $$res;
+            }, $$cr)();
+    }
+    public matchrule2($$dpth: number, $$cr?: ContextRecorder): Nullable<rule2> {
+        return this.runner<rule2>($$dpth,
+            (log) => {
+                if (log) {
+                    log("rule2");
+                }
+                let $scope$res: Nullable<string>;
+                let $$res: Nullable<rule2> = null;
+                if (true
+                    && ($scope$res = this.regexAccept(String.raw`(?:a)`, $$dpth + 1, $$cr)) !== null
+                ) {
+                    $$res = {kind: ASTKinds.rule2, res: $scope$res};
+                }
+                return $$res;
+            }, $$cr)();
+    }
+    public matchrule3($$dpth: number, $$cr?: ContextRecorder): Nullable<rule3> {
+        return this.runner<rule3>($$dpth,
+            (log) => {
+                if (log) {
+                    log("rule3");
+                }
+                let $scope$cr: Nullable<string>;
+                let $$res: Nullable<rule3> = null;
+                if (true
+                    && ($scope$cr = this.regexAccept(String.raw`(?:b)`, $$dpth + 1, $$cr)) !== null
+                ) {
+                    $$res = {kind: ASTKinds.rule3, cr: $scope$cr};
+                }
+                return $$res;
+            }, $$cr)();
     }
     public test(): boolean {
         const mrk = this.mark();

--- a/src/test/muse/parser.ts
+++ b/src/test/muse/parser.ts
@@ -205,538 +205,538 @@ export class Parser {
     public finished(): boolean {
         return this.pos.overallPos === this.input.length;
     }
-    public matchProgram($$dpth: number, cr?: ContextRecorder): Nullable<Program> {
+    public matchProgram($$dpth: number, $$cr?: ContextRecorder): Nullable<Program> {
         return this.runner<Program>($$dpth,
             (log) => {
                 if (log) {
                     log("Program");
                 }
-                let res: Nullable<Program> = null;
+                let $$res: Nullable<Program> = null;
                 if (true
-                    && this.loop<Melody>(() => this.matchMelody($$dpth + 1, cr), true) !== null
-                    && this.match_($$dpth + 1, cr) !== null
+                    && this.loop<Melody>(() => this.matchMelody($$dpth + 1, $$cr), true) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
                 ) {
-                    res = {kind: ASTKinds.Program, };
+                    $$res = {kind: ASTKinds.Program, };
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchMelody($$dpth: number, cr?: ContextRecorder): Nullable<Melody> {
+    public matchMelody($$dpth: number, $$cr?: ContextRecorder): Nullable<Melody> {
         return this.runner<Melody>($$dpth,
             (log) => {
                 if (log) {
                     log("Melody");
                 }
-                let res: Nullable<Melody> = null;
+                let $$res: Nullable<Melody> = null;
                 if (true
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.regexAccept(String.raw`(?:melody)`, $$dpth + 1, cr) !== null
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.matchKID($$dpth + 1, cr) !== null
-                    && this.loop<Melody_$0>(() => this.matchMelody_$0($$dpth + 1, cr), true) !== null
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.regexAccept(String.raw`(?:start)`, $$dpth + 1, cr) !== null
-                    && this.loop<Stmt>(() => this.matchStmt($$dpth + 1, cr), true) !== null
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.regexAccept(String.raw`(?:end)`, $$dpth + 1, cr) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.regexAccept(String.raw`(?:melody)`, $$dpth + 1, $$cr) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.matchKID($$dpth + 1, $$cr) !== null
+                    && this.loop<Melody_$0>(() => this.matchMelody_$0($$dpth + 1, $$cr), true) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.regexAccept(String.raw`(?:start)`, $$dpth + 1, $$cr) !== null
+                    && this.loop<Stmt>(() => this.matchStmt($$dpth + 1, $$cr), true) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.regexAccept(String.raw`(?:end)`, $$dpth + 1, $$cr) !== null
                 ) {
-                    res = {kind: ASTKinds.Melody, };
+                    $$res = {kind: ASTKinds.Melody, };
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchMelody_$0($$dpth: number, cr?: ContextRecorder): Nullable<Melody_$0> {
+    public matchMelody_$0($$dpth: number, $$cr?: ContextRecorder): Nullable<Melody_$0> {
         return this.runner<Melody_$0>($$dpth,
             (log) => {
                 if (log) {
                     log("Melody_$0");
                 }
-                let res: Nullable<Melody_$0> = null;
+                let $$res: Nullable<Melody_$0> = null;
                 if (true
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.matchKID($$dpth + 1, cr) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.matchKID($$dpth + 1, $$cr) !== null
                 ) {
-                    res = {kind: ASTKinds.Melody_$0, };
+                    $$res = {kind: ASTKinds.Melody_$0, };
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchStmt($$dpth: number, cr?: ContextRecorder): Nullable<Stmt> {
+    public matchStmt($$dpth: number, $$cr?: ContextRecorder): Nullable<Stmt> {
         return this.choice<Stmt>([
-            () => this.matchStmt_1($$dpth + 1, cr),
-            () => this.matchStmt_2($$dpth + 1, cr),
-            () => this.matchStmt_3($$dpth + 1, cr),
-            () => this.matchStmt_4($$dpth + 1, cr),
+            () => this.matchStmt_1($$dpth + 1, $$cr),
+            () => this.matchStmt_2($$dpth + 1, $$cr),
+            () => this.matchStmt_3($$dpth + 1, $$cr),
+            () => this.matchStmt_4($$dpth + 1, $$cr),
         ]);
     }
-    public matchStmt_1($$dpth: number, cr?: ContextRecorder): Nullable<Stmt_1> {
-        return this.matchKeyStmt($$dpth + 1, cr);
+    public matchStmt_1($$dpth: number, $$cr?: ContextRecorder): Nullable<Stmt_1> {
+        return this.matchKeyStmt($$dpth + 1, $$cr);
     }
-    public matchStmt_2($$dpth: number, cr?: ContextRecorder): Nullable<Stmt_2> {
-        return this.matchAssignStmt($$dpth + 1, cr);
+    public matchStmt_2($$dpth: number, $$cr?: ContextRecorder): Nullable<Stmt_2> {
+        return this.matchAssignStmt($$dpth + 1, $$cr);
     }
-    public matchStmt_3($$dpth: number, cr?: ContextRecorder): Nullable<Stmt_3> {
-        return this.matchForStmt($$dpth + 1, cr);
+    public matchStmt_3($$dpth: number, $$cr?: ContextRecorder): Nullable<Stmt_3> {
+        return this.matchForStmt($$dpth + 1, $$cr);
     }
-    public matchStmt_4($$dpth: number, cr?: ContextRecorder): Nullable<Stmt_4> {
-        return this.matchIfStmt($$dpth + 1, cr);
+    public matchStmt_4($$dpth: number, $$cr?: ContextRecorder): Nullable<Stmt_4> {
+        return this.matchIfStmt($$dpth + 1, $$cr);
     }
-    public matchKeyStmt($$dpth: number, cr?: ContextRecorder): Nullable<KeyStmt> {
+    public matchKeyStmt($$dpth: number, $$cr?: ContextRecorder): Nullable<KeyStmt> {
         return this.runner<KeyStmt>($$dpth,
             (log) => {
                 if (log) {
                     log("KeyStmt");
                 }
-                let res: Nullable<KeyStmt> = null;
+                let $$res: Nullable<KeyStmt> = null;
                 if (true
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.matchFuncs($$dpth + 1, cr) !== null
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.matchExpr($$dpth + 1, cr) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.matchFuncs($$dpth + 1, $$cr) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.matchExpr($$dpth + 1, $$cr) !== null
                 ) {
-                    res = {kind: ASTKinds.KeyStmt, };
+                    $$res = {kind: ASTKinds.KeyStmt, };
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchAssignStmt($$dpth: number, cr?: ContextRecorder): Nullable<AssignStmt> {
+    public matchAssignStmt($$dpth: number, $$cr?: ContextRecorder): Nullable<AssignStmt> {
         return this.runner<AssignStmt>($$dpth,
             (log) => {
                 if (log) {
                     log("AssignStmt");
                 }
-                let res: Nullable<AssignStmt> = null;
+                let $$res: Nullable<AssignStmt> = null;
                 if (true
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.matchKID($$dpth + 1, cr) !== null
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.regexAccept(String.raw`(?:=)`, $$dpth + 1, cr) !== null
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.matchExpr($$dpth + 1, cr) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.matchKID($$dpth + 1, $$cr) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.regexAccept(String.raw`(?:=)`, $$dpth + 1, $$cr) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.matchExpr($$dpth + 1, $$cr) !== null
                 ) {
-                    res = {kind: ASTKinds.AssignStmt, };
+                    $$res = {kind: ASTKinds.AssignStmt, };
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchForStmt($$dpth: number, cr?: ContextRecorder): Nullable<ForStmt> {
+    public matchForStmt($$dpth: number, $$cr?: ContextRecorder): Nullable<ForStmt> {
         return this.runner<ForStmt>($$dpth,
             (log) => {
                 if (log) {
                     log("ForStmt");
                 }
-                let res: Nullable<ForStmt> = null;
+                let $$res: Nullable<ForStmt> = null;
                 if (true
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.regexAccept(String.raw`(?:for)`, $$dpth + 1, cr) !== null
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.matchKID($$dpth + 1, cr) !== null
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.regexAccept(String.raw`(?:from)`, $$dpth + 1, cr) !== null
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.matchExpr($$dpth + 1, cr) !== null
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.regexAccept(String.raw`(?:to)`, $$dpth + 1, cr) !== null
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.matchExpr($$dpth + 1, cr) !== null
-                    && this.loop<Stmt>(() => this.matchStmt($$dpth + 1, cr), true) !== null
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.regexAccept(String.raw`(?:end)`, $$dpth + 1, cr) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.regexAccept(String.raw`(?:for)`, $$dpth + 1, $$cr) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.matchKID($$dpth + 1, $$cr) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.regexAccept(String.raw`(?:from)`, $$dpth + 1, $$cr) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.matchExpr($$dpth + 1, $$cr) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.regexAccept(String.raw`(?:to)`, $$dpth + 1, $$cr) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.matchExpr($$dpth + 1, $$cr) !== null
+                    && this.loop<Stmt>(() => this.matchStmt($$dpth + 1, $$cr), true) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.regexAccept(String.raw`(?:end)`, $$dpth + 1, $$cr) !== null
                 ) {
-                    res = {kind: ASTKinds.ForStmt, };
+                    $$res = {kind: ASTKinds.ForStmt, };
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchIfStmt($$dpth: number, cr?: ContextRecorder): Nullable<IfStmt> {
+    public matchIfStmt($$dpth: number, $$cr?: ContextRecorder): Nullable<IfStmt> {
         return this.runner<IfStmt>($$dpth,
             (log) => {
                 if (log) {
                     log("IfStmt");
                 }
-                let res: Nullable<IfStmt> = null;
+                let $$res: Nullable<IfStmt> = null;
                 if (true
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.regexAccept(String.raw`(?:if)`, $$dpth + 1, cr) !== null
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.matchExpr($$dpth + 1, cr) !== null
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.regexAccept(String.raw`(?:then)`, $$dpth + 1, cr) !== null
-                    && this.loop<Stmt>(() => this.matchStmt($$dpth + 1, cr), true) !== null
-                    && this.matchIfStmt_$0($$dpth + 1, cr) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.regexAccept(String.raw`(?:if)`, $$dpth + 1, $$cr) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.matchExpr($$dpth + 1, $$cr) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.regexAccept(String.raw`(?:then)`, $$dpth + 1, $$cr) !== null
+                    && this.loop<Stmt>(() => this.matchStmt($$dpth + 1, $$cr), true) !== null
+                    && this.matchIfStmt_$0($$dpth + 1, $$cr) !== null
                 ) {
-                    res = {kind: ASTKinds.IfStmt, };
+                    $$res = {kind: ASTKinds.IfStmt, };
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchIfStmt_$0($$dpth: number, cr?: ContextRecorder): Nullable<IfStmt_$0> {
+    public matchIfStmt_$0($$dpth: number, $$cr?: ContextRecorder): Nullable<IfStmt_$0> {
         return this.choice<IfStmt_$0>([
-            () => this.matchIfStmt_$0_1($$dpth + 1, cr),
-            () => this.matchIfStmt_$0_2($$dpth + 1, cr),
+            () => this.matchIfStmt_$0_1($$dpth + 1, $$cr),
+            () => this.matchIfStmt_$0_2($$dpth + 1, $$cr),
         ]);
     }
-    public matchIfStmt_$0_1($$dpth: number, cr?: ContextRecorder): Nullable<IfStmt_$0_1> {
+    public matchIfStmt_$0_1($$dpth: number, $$cr?: ContextRecorder): Nullable<IfStmt_$0_1> {
         return this.runner<IfStmt_$0_1>($$dpth,
             (log) => {
                 if (log) {
                     log("IfStmt_$0_1");
                 }
-                let res: Nullable<IfStmt_$0_1> = null;
+                let $$res: Nullable<IfStmt_$0_1> = null;
                 if (true
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.regexAccept(String.raw`(?:end)`, $$dpth + 1, cr) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.regexAccept(String.raw`(?:end)`, $$dpth + 1, $$cr) !== null
                 ) {
-                    res = {kind: ASTKinds.IfStmt_$0_1, };
+                    $$res = {kind: ASTKinds.IfStmt_$0_1, };
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchIfStmt_$0_2($$dpth: number, cr?: ContextRecorder): Nullable<IfStmt_$0_2> {
+    public matchIfStmt_$0_2($$dpth: number, $$cr?: ContextRecorder): Nullable<IfStmt_$0_2> {
         return this.runner<IfStmt_$0_2>($$dpth,
             (log) => {
                 if (log) {
                     log("IfStmt_$0_2");
                 }
-                let res: Nullable<IfStmt_$0_2> = null;
+                let $$res: Nullable<IfStmt_$0_2> = null;
                 if (true
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.regexAccept(String.raw`(?:else)`, $$dpth + 1, cr) !== null
-                    && this.loop<Stmt>(() => this.matchStmt($$dpth + 1, cr), true) !== null
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.regexAccept(String.raw`(?:end)`, $$dpth + 1, cr) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.regexAccept(String.raw`(?:else)`, $$dpth + 1, $$cr) !== null
+                    && this.loop<Stmt>(() => this.matchStmt($$dpth + 1, $$cr), true) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.regexAccept(String.raw`(?:end)`, $$dpth + 1, $$cr) !== null
                 ) {
-                    res = {kind: ASTKinds.IfStmt_$0_2, };
+                    $$res = {kind: ASTKinds.IfStmt_$0_2, };
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchFuncExpr($$dpth: number, cr?: ContextRecorder): Nullable<FuncExpr> {
+    public matchFuncExpr($$dpth: number, $$cr?: ContextRecorder): Nullable<FuncExpr> {
         return this.runner<FuncExpr>($$dpth,
             (log) => {
                 if (log) {
                     log("FuncExpr");
                 }
-                let res: Nullable<FuncExpr> = null;
+                let $$res: Nullable<FuncExpr> = null;
                 if (true
-                    && this.matchExpr($$dpth + 1, cr) !== null
-                    && this.loop<FuncExpr_$0>(() => this.matchFuncExpr_$0($$dpth + 1, cr), true) !== null
+                    && this.matchExpr($$dpth + 1, $$cr) !== null
+                    && this.loop<FuncExpr_$0>(() => this.matchFuncExpr_$0($$dpth + 1, $$cr), true) !== null
                 ) {
-                    res = {kind: ASTKinds.FuncExpr, };
+                    $$res = {kind: ASTKinds.FuncExpr, };
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchFuncExpr_$0($$dpth: number, cr?: ContextRecorder): Nullable<FuncExpr_$0> {
+    public matchFuncExpr_$0($$dpth: number, $$cr?: ContextRecorder): Nullable<FuncExpr_$0> {
         return this.runner<FuncExpr_$0>($$dpth,
             (log) => {
                 if (log) {
                     log("FuncExpr_$0");
                 }
-                let res: Nullable<FuncExpr_$0> = null;
+                let $$res: Nullable<FuncExpr_$0> = null;
                 if (true
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.matchExpr($$dpth + 1, cr) !== null
-                    && this.loop<string>(() => this.regexAccept(String.raw`(?: )`, $$dpth + 1, cr), true) !== null
-                    && this.negate(() => this.regexAccept(String.raw`(?:\n)`, $$dpth + 1, cr)) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.matchExpr($$dpth + 1, $$cr) !== null
+                    && this.loop<string>(() => this.regexAccept(String.raw`(?: )`, $$dpth + 1, $$cr), true) !== null
+                    && this.negate(() => this.regexAccept(String.raw`(?:\n)`, $$dpth + 1, $$cr)) !== null
                 ) {
-                    res = {kind: ASTKinds.FuncExpr_$0, };
+                    $$res = {kind: ASTKinds.FuncExpr_$0, };
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchExpr($$dpth: number, cr?: ContextRecorder): Nullable<Expr> {
-        return this.matchEq($$dpth + 1, cr);
+    public matchExpr($$dpth: number, $$cr?: ContextRecorder): Nullable<Expr> {
+        return this.matchEq($$dpth + 1, $$cr);
     }
-    public matchEq($$dpth: number, cr?: ContextRecorder): Nullable<Eq> {
+    public matchEq($$dpth: number, $$cr?: ContextRecorder): Nullable<Eq> {
         return this.runner<Eq>($$dpth,
             (log) => {
                 if (log) {
                     log("Eq");
                 }
-                let res: Nullable<Eq> = null;
+                let $$res: Nullable<Eq> = null;
                 if (true
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.matchComp($$dpth + 1, cr) !== null
-                    && this.loop<Eq_$0>(() => this.matchEq_$0($$dpth + 1, cr), true) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.matchComp($$dpth + 1, $$cr) !== null
+                    && this.loop<Eq_$0>(() => this.matchEq_$0($$dpth + 1, $$cr), true) !== null
                 ) {
-                    res = {kind: ASTKinds.Eq, };
+                    $$res = {kind: ASTKinds.Eq, };
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchEq_$0($$dpth: number, cr?: ContextRecorder): Nullable<Eq_$0> {
+    public matchEq_$0($$dpth: number, $$cr?: ContextRecorder): Nullable<Eq_$0> {
         return this.runner<Eq_$0>($$dpth,
             (log) => {
                 if (log) {
                     log("Eq_$0");
                 }
-                let res: Nullable<Eq_$0> = null;
+                let $$res: Nullable<Eq_$0> = null;
                 if (true
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.regexAccept(String.raw`(?:==)`, $$dpth + 1, cr) !== null
-                    && this.matchComp($$dpth + 1, cr) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.regexAccept(String.raw`(?:==)`, $$dpth + 1, $$cr) !== null
+                    && this.matchComp($$dpth + 1, $$cr) !== null
                 ) {
-                    res = {kind: ASTKinds.Eq_$0, };
+                    $$res = {kind: ASTKinds.Eq_$0, };
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchComp($$dpth: number, cr?: ContextRecorder): Nullable<Comp> {
+    public matchComp($$dpth: number, $$cr?: ContextRecorder): Nullable<Comp> {
         return this.runner<Comp>($$dpth,
             (log) => {
                 if (log) {
                     log("Comp");
                 }
-                let res: Nullable<Comp> = null;
+                let $$res: Nullable<Comp> = null;
                 if (true
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.matchSum($$dpth + 1, cr) !== null
-                    && this.loop<Comp_$0>(() => this.matchComp_$0($$dpth + 1, cr), true) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.matchSum($$dpth + 1, $$cr) !== null
+                    && this.loop<Comp_$0>(() => this.matchComp_$0($$dpth + 1, $$cr), true) !== null
                 ) {
-                    res = {kind: ASTKinds.Comp, };
+                    $$res = {kind: ASTKinds.Comp, };
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchComp_$0($$dpth: number, cr?: ContextRecorder): Nullable<Comp_$0> {
+    public matchComp_$0($$dpth: number, $$cr?: ContextRecorder): Nullable<Comp_$0> {
         return this.runner<Comp_$0>($$dpth,
             (log) => {
                 if (log) {
                     log("Comp_$0");
                 }
-                let res: Nullable<Comp_$0> = null;
+                let $$res: Nullable<Comp_$0> = null;
                 if (true
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.matchCompare($$dpth + 1, cr) !== null
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.matchSum($$dpth + 1, cr) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.matchCompare($$dpth + 1, $$cr) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.matchSum($$dpth + 1, $$cr) !== null
                 ) {
-                    res = {kind: ASTKinds.Comp_$0, };
+                    $$res = {kind: ASTKinds.Comp_$0, };
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchSum($$dpth: number, cr?: ContextRecorder): Nullable<Sum> {
+    public matchSum($$dpth: number, $$cr?: ContextRecorder): Nullable<Sum> {
         return this.runner<Sum>($$dpth,
             (log) => {
                 if (log) {
                     log("Sum");
                 }
-                let res: Nullable<Sum> = null;
+                let $$res: Nullable<Sum> = null;
                 if (true
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.matchProduct($$dpth + 1, cr) !== null
-                    && this.loop<Sum_$0>(() => this.matchSum_$0($$dpth + 1, cr), true) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.matchProduct($$dpth + 1, $$cr) !== null
+                    && this.loop<Sum_$0>(() => this.matchSum_$0($$dpth + 1, $$cr), true) !== null
                 ) {
-                    res = {kind: ASTKinds.Sum, };
+                    $$res = {kind: ASTKinds.Sum, };
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchSum_$0($$dpth: number, cr?: ContextRecorder): Nullable<Sum_$0> {
+    public matchSum_$0($$dpth: number, $$cr?: ContextRecorder): Nullable<Sum_$0> {
         return this.runner<Sum_$0>($$dpth,
             (log) => {
                 if (log) {
                     log("Sum_$0");
                 }
-                let res: Nullable<Sum_$0> = null;
+                let $$res: Nullable<Sum_$0> = null;
                 if (true
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.matchPlusMinus($$dpth + 1, cr) !== null
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.matchProduct($$dpth + 1, cr) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.matchPlusMinus($$dpth + 1, $$cr) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.matchProduct($$dpth + 1, $$cr) !== null
                 ) {
-                    res = {kind: ASTKinds.Sum_$0, };
+                    $$res = {kind: ASTKinds.Sum_$0, };
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchProduct($$dpth: number, cr?: ContextRecorder): Nullable<Product> {
+    public matchProduct($$dpth: number, $$cr?: ContextRecorder): Nullable<Product> {
         return this.runner<Product>($$dpth,
             (log) => {
                 if (log) {
                     log("Product");
                 }
-                let res: Nullable<Product> = null;
+                let $$res: Nullable<Product> = null;
                 if (true
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.matchAtom($$dpth + 1, cr) !== null
-                    && this.loop<Product_$0>(() => this.matchProduct_$0($$dpth + 1, cr), true) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.matchAtom($$dpth + 1, $$cr) !== null
+                    && this.loop<Product_$0>(() => this.matchProduct_$0($$dpth + 1, $$cr), true) !== null
                 ) {
-                    res = {kind: ASTKinds.Product, };
+                    $$res = {kind: ASTKinds.Product, };
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchProduct_$0($$dpth: number, cr?: ContextRecorder): Nullable<Product_$0> {
+    public matchProduct_$0($$dpth: number, $$cr?: ContextRecorder): Nullable<Product_$0> {
         return this.runner<Product_$0>($$dpth,
             (log) => {
                 if (log) {
                     log("Product_$0");
                 }
-                let res: Nullable<Product_$0> = null;
+                let $$res: Nullable<Product_$0> = null;
                 if (true
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.matchMulDiv($$dpth + 1, cr) !== null
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.matchAtom($$dpth + 1, cr) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.matchMulDiv($$dpth + 1, $$cr) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.matchAtom($$dpth + 1, $$cr) !== null
                 ) {
-                    res = {kind: ASTKinds.Product_$0, };
+                    $$res = {kind: ASTKinds.Product_$0, };
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchAtom($$dpth: number, cr?: ContextRecorder): Nullable<Atom> {
+    public matchAtom($$dpth: number, $$cr?: ContextRecorder): Nullable<Atom> {
         return this.choice<Atom>([
-            () => this.matchAtom_1($$dpth + 1, cr),
-            () => this.matchAtom_2($$dpth + 1, cr),
-            () => this.matchAtom_3($$dpth + 1, cr),
-            () => this.matchAtom_4($$dpth + 1, cr),
+            () => this.matchAtom_1($$dpth + 1, $$cr),
+            () => this.matchAtom_2($$dpth + 1, $$cr),
+            () => this.matchAtom_3($$dpth + 1, $$cr),
+            () => this.matchAtom_4($$dpth + 1, $$cr),
         ]);
     }
-    public matchAtom_1($$dpth: number, cr?: ContextRecorder): Nullable<Atom_1> {
-        return this.matchNoteLit($$dpth + 1, cr);
+    public matchAtom_1($$dpth: number, $$cr?: ContextRecorder): Nullable<Atom_1> {
+        return this.matchNoteLit($$dpth + 1, $$cr);
     }
-    public matchAtom_2($$dpth: number, cr?: ContextRecorder): Nullable<Atom_2> {
-        return this.matchKID($$dpth + 1, cr);
+    public matchAtom_2($$dpth: number, $$cr?: ContextRecorder): Nullable<Atom_2> {
+        return this.matchKID($$dpth + 1, $$cr);
     }
-    public matchAtom_3($$dpth: number, cr?: ContextRecorder): Nullable<Atom_3> {
-        return this.matchINT($$dpth + 1, cr);
+    public matchAtom_3($$dpth: number, $$cr?: ContextRecorder): Nullable<Atom_3> {
+        return this.matchINT($$dpth + 1, $$cr);
     }
-    public matchAtom_4($$dpth: number, cr?: ContextRecorder): Nullable<Atom_4> {
+    public matchAtom_4($$dpth: number, $$cr?: ContextRecorder): Nullable<Atom_4> {
         return this.runner<Atom_4>($$dpth,
             (log) => {
                 if (log) {
                     log("Atom_4");
                 }
-                let res: Nullable<Atom_4> = null;
+                let $$res: Nullable<Atom_4> = null;
                 if (true
-                    && this.regexAccept(String.raw`(?:\()`, $$dpth + 1, cr) !== null
-                    && this.matchFuncExpr($$dpth + 1, cr) !== null
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.regexAccept(String.raw`(?:\))`, $$dpth + 1, cr) !== null
+                    && this.regexAccept(String.raw`(?:\()`, $$dpth + 1, $$cr) !== null
+                    && this.matchFuncExpr($$dpth + 1, $$cr) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.regexAccept(String.raw`(?:\))`, $$dpth + 1, $$cr) !== null
                 ) {
-                    res = {kind: ASTKinds.Atom_4, };
+                    $$res = {kind: ASTKinds.Atom_4, };
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchPlusMinus($$dpth: number, cr?: ContextRecorder): Nullable<PlusMinus> {
+    public matchPlusMinus($$dpth: number, $$cr?: ContextRecorder): Nullable<PlusMinus> {
         return this.choice<PlusMinus>([
-            () => this.matchPlusMinus_1($$dpth + 1, cr),
-            () => this.matchPlusMinus_2($$dpth + 1, cr),
+            () => this.matchPlusMinus_1($$dpth + 1, $$cr),
+            () => this.matchPlusMinus_2($$dpth + 1, $$cr),
         ]);
     }
-    public matchPlusMinus_1($$dpth: number, cr?: ContextRecorder): Nullable<PlusMinus_1> {
-        return this.regexAccept(String.raw`(?:\+)`, $$dpth + 1, cr);
+    public matchPlusMinus_1($$dpth: number, $$cr?: ContextRecorder): Nullable<PlusMinus_1> {
+        return this.regexAccept(String.raw`(?:\+)`, $$dpth + 1, $$cr);
     }
-    public matchPlusMinus_2($$dpth: number, cr?: ContextRecorder): Nullable<PlusMinus_2> {
-        return this.regexAccept(String.raw`(?:-)`, $$dpth + 1, cr);
+    public matchPlusMinus_2($$dpth: number, $$cr?: ContextRecorder): Nullable<PlusMinus_2> {
+        return this.regexAccept(String.raw`(?:-)`, $$dpth + 1, $$cr);
     }
-    public matchMulDiv($$dpth: number, cr?: ContextRecorder): Nullable<MulDiv> {
+    public matchMulDiv($$dpth: number, $$cr?: ContextRecorder): Nullable<MulDiv> {
         return this.choice<MulDiv>([
-            () => this.matchMulDiv_1($$dpth + 1, cr),
-            () => this.matchMulDiv_2($$dpth + 1, cr),
-            () => this.matchMulDiv_3($$dpth + 1, cr),
+            () => this.matchMulDiv_1($$dpth + 1, $$cr),
+            () => this.matchMulDiv_2($$dpth + 1, $$cr),
+            () => this.matchMulDiv_3($$dpth + 1, $$cr),
         ]);
     }
-    public matchMulDiv_1($$dpth: number, cr?: ContextRecorder): Nullable<MulDiv_1> {
-        return this.regexAccept(String.raw`(?:\*)`, $$dpth + 1, cr);
+    public matchMulDiv_1($$dpth: number, $$cr?: ContextRecorder): Nullable<MulDiv_1> {
+        return this.regexAccept(String.raw`(?:\*)`, $$dpth + 1, $$cr);
     }
-    public matchMulDiv_2($$dpth: number, cr?: ContextRecorder): Nullable<MulDiv_2> {
-        return this.regexAccept(String.raw`(?:\/)`, $$dpth + 1, cr);
+    public matchMulDiv_2($$dpth: number, $$cr?: ContextRecorder): Nullable<MulDiv_2> {
+        return this.regexAccept(String.raw`(?:\/)`, $$dpth + 1, $$cr);
     }
-    public matchMulDiv_3($$dpth: number, cr?: ContextRecorder): Nullable<MulDiv_3> {
-        return this.regexAccept(String.raw`(?:%)`, $$dpth + 1, cr);
+    public matchMulDiv_3($$dpth: number, $$cr?: ContextRecorder): Nullable<MulDiv_3> {
+        return this.regexAccept(String.raw`(?:%)`, $$dpth + 1, $$cr);
     }
-    public matchCompare($$dpth: number, cr?: ContextRecorder): Nullable<Compare> {
+    public matchCompare($$dpth: number, $$cr?: ContextRecorder): Nullable<Compare> {
         return this.choice<Compare>([
-            () => this.matchCompare_1($$dpth + 1, cr),
-            () => this.matchCompare_2($$dpth + 1, cr),
-            () => this.matchCompare_3($$dpth + 1, cr),
-            () => this.matchCompare_4($$dpth + 1, cr),
+            () => this.matchCompare_1($$dpth + 1, $$cr),
+            () => this.matchCompare_2($$dpth + 1, $$cr),
+            () => this.matchCompare_3($$dpth + 1, $$cr),
+            () => this.matchCompare_4($$dpth + 1, $$cr),
         ]);
     }
-    public matchCompare_1($$dpth: number, cr?: ContextRecorder): Nullable<Compare_1> {
-        return this.regexAccept(String.raw`(?:<=)`, $$dpth + 1, cr);
+    public matchCompare_1($$dpth: number, $$cr?: ContextRecorder): Nullable<Compare_1> {
+        return this.regexAccept(String.raw`(?:<=)`, $$dpth + 1, $$cr);
     }
-    public matchCompare_2($$dpth: number, cr?: ContextRecorder): Nullable<Compare_2> {
-        return this.regexAccept(String.raw`(?:>=)`, $$dpth + 1, cr);
+    public matchCompare_2($$dpth: number, $$cr?: ContextRecorder): Nullable<Compare_2> {
+        return this.regexAccept(String.raw`(?:>=)`, $$dpth + 1, $$cr);
     }
-    public matchCompare_3($$dpth: number, cr?: ContextRecorder): Nullable<Compare_3> {
-        return this.regexAccept(String.raw`(?:<)`, $$dpth + 1, cr);
+    public matchCompare_3($$dpth: number, $$cr?: ContextRecorder): Nullable<Compare_3> {
+        return this.regexAccept(String.raw`(?:<)`, $$dpth + 1, $$cr);
     }
-    public matchCompare_4($$dpth: number, cr?: ContextRecorder): Nullable<Compare_4> {
-        return this.regexAccept(String.raw`(?:>)`, $$dpth + 1, cr);
+    public matchCompare_4($$dpth: number, $$cr?: ContextRecorder): Nullable<Compare_4> {
+        return this.regexAccept(String.raw`(?:>)`, $$dpth + 1, $$cr);
     }
-    public matchNoteLit($$dpth: number, cr?: ContextRecorder): Nullable<NoteLit> {
-        return this.regexAccept(String.raw`(?:[A-G][#b]?\d)`, $$dpth + 1, cr);
+    public matchNoteLit($$dpth: number, $$cr?: ContextRecorder): Nullable<NoteLit> {
+        return this.regexAccept(String.raw`(?:[A-G][#b]?\d)`, $$dpth + 1, $$cr);
     }
-    public matchINT($$dpth: number, cr?: ContextRecorder): Nullable<INT> {
-        return this.regexAccept(String.raw`(?:[0-9]+)`, $$dpth + 1, cr);
+    public matchINT($$dpth: number, $$cr?: ContextRecorder): Nullable<INT> {
+        return this.regexAccept(String.raw`(?:[0-9]+)`, $$dpth + 1, $$cr);
     }
-    public matchKeyword($$dpth: number, cr?: ContextRecorder): Nullable<Keyword> {
+    public matchKeyword($$dpth: number, $$cr?: ContextRecorder): Nullable<Keyword> {
         return this.choice<Keyword>([
-            () => this.matchKeyword_1($$dpth + 1, cr),
-            () => this.matchKeyword_2($$dpth + 1, cr),
-            () => this.matchKeyword_3($$dpth + 1, cr),
-            () => this.matchKeyword_4($$dpth + 1, cr),
-            () => this.matchKeyword_5($$dpth + 1, cr),
-            () => this.matchKeyword_6($$dpth + 1, cr),
+            () => this.matchKeyword_1($$dpth + 1, $$cr),
+            () => this.matchKeyword_2($$dpth + 1, $$cr),
+            () => this.matchKeyword_3($$dpth + 1, $$cr),
+            () => this.matchKeyword_4($$dpth + 1, $$cr),
+            () => this.matchKeyword_5($$dpth + 1, $$cr),
+            () => this.matchKeyword_6($$dpth + 1, $$cr),
         ]);
     }
-    public matchKeyword_1($$dpth: number, cr?: ContextRecorder): Nullable<Keyword_1> {
-        return this.regexAccept(String.raw`(?:start)`, $$dpth + 1, cr);
+    public matchKeyword_1($$dpth: number, $$cr?: ContextRecorder): Nullable<Keyword_1> {
+        return this.regexAccept(String.raw`(?:start)`, $$dpth + 1, $$cr);
     }
-    public matchKeyword_2($$dpth: number, cr?: ContextRecorder): Nullable<Keyword_2> {
-        return this.regexAccept(String.raw`(?:end)`, $$dpth + 1, cr);
+    public matchKeyword_2($$dpth: number, $$cr?: ContextRecorder): Nullable<Keyword_2> {
+        return this.regexAccept(String.raw`(?:end)`, $$dpth + 1, $$cr);
     }
-    public matchKeyword_3($$dpth: number, cr?: ContextRecorder): Nullable<Keyword_3> {
-        return this.regexAccept(String.raw`(?:for)`, $$dpth + 1, cr);
+    public matchKeyword_3($$dpth: number, $$cr?: ContextRecorder): Nullable<Keyword_3> {
+        return this.regexAccept(String.raw`(?:for)`, $$dpth + 1, $$cr);
     }
-    public matchKeyword_4($$dpth: number, cr?: ContextRecorder): Nullable<Keyword_4> {
-        return this.regexAccept(String.raw`(?:else)`, $$dpth + 1, cr);
+    public matchKeyword_4($$dpth: number, $$cr?: ContextRecorder): Nullable<Keyword_4> {
+        return this.regexAccept(String.raw`(?:else)`, $$dpth + 1, $$cr);
     }
-    public matchKeyword_5($$dpth: number, cr?: ContextRecorder): Nullable<Keyword_5> {
-        return this.regexAccept(String.raw`(?:if)`, $$dpth + 1, cr);
+    public matchKeyword_5($$dpth: number, $$cr?: ContextRecorder): Nullable<Keyword_5> {
+        return this.regexAccept(String.raw`(?:if)`, $$dpth + 1, $$cr);
     }
-    public matchKeyword_6($$dpth: number, cr?: ContextRecorder): Nullable<Keyword_6> {
-        return this.regexAccept(String.raw`(?:then)`, $$dpth + 1, cr);
+    public matchKeyword_6($$dpth: number, $$cr?: ContextRecorder): Nullable<Keyword_6> {
+        return this.regexAccept(String.raw`(?:then)`, $$dpth + 1, $$cr);
     }
-    public matchFuncs($$dpth: number, cr?: ContextRecorder): Nullable<Funcs> {
+    public matchFuncs($$dpth: number, $$cr?: ContextRecorder): Nullable<Funcs> {
         return this.choice<Funcs>([
-            () => this.matchFuncs_1($$dpth + 1, cr),
-            () => this.matchFuncs_2($$dpth + 1, cr),
+            () => this.matchFuncs_1($$dpth + 1, $$cr),
+            () => this.matchFuncs_2($$dpth + 1, $$cr),
         ]);
     }
-    public matchFuncs_1($$dpth: number, cr?: ContextRecorder): Nullable<Funcs_1> {
-        return this.regexAccept(String.raw`(?:play)`, $$dpth + 1, cr);
+    public matchFuncs_1($$dpth: number, $$cr?: ContextRecorder): Nullable<Funcs_1> {
+        return this.regexAccept(String.raw`(?:play)`, $$dpth + 1, $$cr);
     }
-    public matchFuncs_2($$dpth: number, cr?: ContextRecorder): Nullable<Funcs_2> {
-        return this.regexAccept(String.raw`(?:wait)`, $$dpth + 1, cr);
+    public matchFuncs_2($$dpth: number, $$cr?: ContextRecorder): Nullable<Funcs_2> {
+        return this.regexAccept(String.raw`(?:wait)`, $$dpth + 1, $$cr);
     }
-    public matchKID($$dpth: number, cr?: ContextRecorder): Nullable<KID> {
+    public matchKID($$dpth: number, $$cr?: ContextRecorder): Nullable<KID> {
         return this.runner<KID>($$dpth,
             (log) => {
                 if (log) {
                     log("KID");
                 }
-                let res: Nullable<KID> = null;
+                let $$res: Nullable<KID> = null;
                 if (true
-                    && this.negate(() => this.matchKeyword($$dpth + 1, cr)) !== null
-                    && this.matchID($$dpth + 1, cr) !== null
+                    && this.negate(() => this.matchKeyword($$dpth + 1, $$cr)) !== null
+                    && this.matchID($$dpth + 1, $$cr) !== null
                 ) {
-                    res = {kind: ASTKinds.KID, };
+                    $$res = {kind: ASTKinds.KID, };
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchID($$dpth: number, cr?: ContextRecorder): Nullable<ID> {
-        return this.regexAccept(String.raw`(?:[a-zA-Z_]+)`, $$dpth + 1, cr);
+    public matchID($$dpth: number, $$cr?: ContextRecorder): Nullable<ID> {
+        return this.regexAccept(String.raw`(?:[a-zA-Z_]+)`, $$dpth + 1, $$cr);
     }
-    public match_($$dpth: number, cr?: ContextRecorder): Nullable<_> {
-        return this.loop<string>(() => this.regexAccept(String.raw`(?:\s)`, $$dpth + 1, cr), true);
+    public match_($$dpth: number, $$cr?: ContextRecorder): Nullable<_> {
+        return this.loop<string>(() => this.regexAccept(String.raw`(?:\s)`, $$dpth + 1, $$cr), true);
     }
     public test(): boolean {
         const mrk = this.mark();

--- a/src/test/pos_test/parser.ts
+++ b/src/test/pos_test/parser.ts
@@ -45,34 +45,34 @@ export class Parser {
     public finished(): boolean {
         return this.pos.overallPos === this.input.length;
     }
-    public matchEXPR($$dpth: number, cr?: ContextRecorder): Nullable<EXPR> {
+    public matchEXPR($$dpth: number, $$cr?: ContextRecorder): Nullable<EXPR> {
         return this.runner<EXPR>($$dpth,
             (log) => {
                 if (log) {
                     log("EXPR");
                 }
-                let strt: Nullable<PosInfo>;
-                let left: Nullable<Nullable<EXPR>>;
-                let end: Nullable<PosInfo>;
-                let right: Nullable<Nullable<EXPR>>;
-                let res: Nullable<EXPR> = null;
+                let $scope$strt: Nullable<PosInfo>;
+                let $scope$left: Nullable<Nullable<EXPR>>;
+                let $scope$end: Nullable<PosInfo>;
+                let $scope$right: Nullable<Nullable<EXPR>>;
+                let $$res: Nullable<EXPR> = null;
                 if (true
-                    && this.match_($$dpth + 1, cr) !== null
-                    && (strt = this.mark()) !== null
-                    && this.regexAccept(String.raw`(?:\()`, $$dpth + 1, cr) !== null
-                    && ((left = this.matchEXPR($$dpth + 1, cr)) || true)
-                    && this.regexAccept(String.raw`(?:\))`, $$dpth + 1, cr) !== null
-                    && (end = this.mark()) !== null
-                    && ((right = this.matchEXPR($$dpth + 1, cr)) || true)
-                    && this.match_($$dpth + 1, cr) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && ($scope$strt = this.mark()) !== null
+                    && this.regexAccept(String.raw`(?:\()`, $$dpth + 1, $$cr) !== null
+                    && (($scope$left = this.matchEXPR($$dpth + 1, $$cr)) || true)
+                    && this.regexAccept(String.raw`(?:\))`, $$dpth + 1, $$cr) !== null
+                    && ($scope$end = this.mark()) !== null
+                    && (($scope$right = this.matchEXPR($$dpth + 1, $$cr)) || true)
+                    && this.match_($$dpth + 1, $$cr) !== null
                 ) {
-                    res = {kind: ASTKinds.EXPR, strt, left, end, right};
+                    $$res = {kind: ASTKinds.EXPR, strt: $scope$strt, left: $scope$left, end: $scope$end, right: $scope$right};
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public match_($$dpth: number, cr?: ContextRecorder): Nullable<_> {
-        return this.regexAccept(String.raw`(?:\s*)`, $$dpth + 1, cr);
+    public match_($$dpth: number, $$cr?: ContextRecorder): Nullable<_> {
+        return this.regexAccept(String.raw`(?:\s*)`, $$dpth + 1, $$cr);
     }
     public test(): boolean {
         const mrk = this.mark();

--- a/src/test/setanta_test/parser.ts
+++ b/src/test/setanta_test/parser.ts
@@ -448,1089 +448,1089 @@ export class Parser {
     public finished(): boolean {
         return this.pos.overallPos === this.input.length;
     }
-    public matchProgram($$dpth: number, cr?: ContextRecorder): Nullable<Program> {
+    public matchProgram($$dpth: number, $$cr?: ContextRecorder): Nullable<Program> {
         return this.runner<Program>($$dpth,
             (log) => {
                 if (log) {
                     log("Program");
                 }
-                let stmts: Nullable<AsgnStmt[]>;
-                let res: Nullable<Program> = null;
+                let $scope$stmts: Nullable<AsgnStmt[]>;
+                let $$res: Nullable<Program> = null;
                 if (true
-                    && (stmts = this.loop<AsgnStmt>(() => this.matchAsgnStmt($$dpth + 1, cr), true)) !== null
-                    && this.match_($$dpth + 1, cr) !== null
+                    && ($scope$stmts = this.loop<AsgnStmt>(() => this.matchAsgnStmt($$dpth + 1, $$cr), true)) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
                 ) {
-                    res = {kind: ASTKinds.Program, stmts};
+                    $$res = {kind: ASTKinds.Program, stmts: $scope$stmts};
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchAsgnStmt($$dpth: number, cr?: ContextRecorder): Nullable<AsgnStmt> {
+    public matchAsgnStmt($$dpth: number, $$cr?: ContextRecorder): Nullable<AsgnStmt> {
         return this.choice<AsgnStmt>([
-            () => this.matchAsgnStmt_1($$dpth + 1, cr),
-            () => this.matchAsgnStmt_2($$dpth + 1, cr),
-            () => this.matchAsgnStmt_3($$dpth + 1, cr),
-            () => this.matchAsgnStmt_4($$dpth + 1, cr),
-            () => this.matchAsgnStmt_5($$dpth + 1, cr),
-            () => this.matchAsgnStmt_6($$dpth + 1, cr),
-            () => this.matchAsgnStmt_7($$dpth + 1, cr),
-            () => this.matchAsgnStmt_8($$dpth + 1, cr),
-            () => this.matchAsgnStmt_9($$dpth + 1, cr),
-            () => this.matchAsgnStmt_10($$dpth + 1, cr),
-            () => this.matchAsgnStmt_11($$dpth + 1, cr),
-            () => this.matchAsgnStmt_12($$dpth + 1, cr),
+            () => this.matchAsgnStmt_1($$dpth + 1, $$cr),
+            () => this.matchAsgnStmt_2($$dpth + 1, $$cr),
+            () => this.matchAsgnStmt_3($$dpth + 1, $$cr),
+            () => this.matchAsgnStmt_4($$dpth + 1, $$cr),
+            () => this.matchAsgnStmt_5($$dpth + 1, $$cr),
+            () => this.matchAsgnStmt_6($$dpth + 1, $$cr),
+            () => this.matchAsgnStmt_7($$dpth + 1, $$cr),
+            () => this.matchAsgnStmt_8($$dpth + 1, $$cr),
+            () => this.matchAsgnStmt_9($$dpth + 1, $$cr),
+            () => this.matchAsgnStmt_10($$dpth + 1, $$cr),
+            () => this.matchAsgnStmt_11($$dpth + 1, $$cr),
+            () => this.matchAsgnStmt_12($$dpth + 1, $$cr),
         ]);
     }
-    public matchAsgnStmt_1($$dpth: number, cr?: ContextRecorder): Nullable<AsgnStmt_1> {
-        return this.matchIfStmt($$dpth + 1, cr);
+    public matchAsgnStmt_1($$dpth: number, $$cr?: ContextRecorder): Nullable<AsgnStmt_1> {
+        return this.matchIfStmt($$dpth + 1, $$cr);
     }
-    public matchAsgnStmt_2($$dpth: number, cr?: ContextRecorder): Nullable<AsgnStmt_2> {
-        return this.matchBlockStmt($$dpth + 1, cr);
+    public matchAsgnStmt_2($$dpth: number, $$cr?: ContextRecorder): Nullable<AsgnStmt_2> {
+        return this.matchBlockStmt($$dpth + 1, $$cr);
     }
-    public matchAsgnStmt_3($$dpth: number, cr?: ContextRecorder): Nullable<AsgnStmt_3> {
-        return this.matchNuairStmt($$dpth + 1, cr);
+    public matchAsgnStmt_3($$dpth: number, $$cr?: ContextRecorder): Nullable<AsgnStmt_3> {
+        return this.matchNuairStmt($$dpth + 1, $$cr);
     }
-    public matchAsgnStmt_4($$dpth: number, cr?: ContextRecorder): Nullable<AsgnStmt_4> {
-        return this.matchLeStmt($$dpth + 1, cr);
+    public matchAsgnStmt_4($$dpth: number, $$cr?: ContextRecorder): Nullable<AsgnStmt_4> {
+        return this.matchLeStmt($$dpth + 1, $$cr);
     }
-    public matchAsgnStmt_5($$dpth: number, cr?: ContextRecorder): Nullable<AsgnStmt_5> {
-        return this.matchCCStmt($$dpth + 1, cr);
+    public matchAsgnStmt_5($$dpth: number, $$cr?: ContextRecorder): Nullable<AsgnStmt_5> {
+        return this.matchCCStmt($$dpth + 1, $$cr);
     }
-    public matchAsgnStmt_6($$dpth: number, cr?: ContextRecorder): Nullable<AsgnStmt_6> {
-        return this.matchBrisStmt($$dpth + 1, cr);
+    public matchAsgnStmt_6($$dpth: number, $$cr?: ContextRecorder): Nullable<AsgnStmt_6> {
+        return this.matchBrisStmt($$dpth + 1, $$cr);
     }
-    public matchAsgnStmt_7($$dpth: number, cr?: ContextRecorder): Nullable<AsgnStmt_7> {
-        return this.matchCtlchStmt($$dpth + 1, cr);
+    public matchAsgnStmt_7($$dpth: number, $$cr?: ContextRecorder): Nullable<AsgnStmt_7> {
+        return this.matchCtlchStmt($$dpth + 1, $$cr);
     }
-    public matchAsgnStmt_8($$dpth: number, cr?: ContextRecorder): Nullable<AsgnStmt_8> {
-        return this.matchGniomhStmt($$dpth + 1, cr);
+    public matchAsgnStmt_8($$dpth: number, $$cr?: ContextRecorder): Nullable<AsgnStmt_8> {
+        return this.matchGniomhStmt($$dpth + 1, $$cr);
     }
-    public matchAsgnStmt_9($$dpth: number, cr?: ContextRecorder): Nullable<AsgnStmt_9> {
-        return this.matchToradhStmt($$dpth + 1, cr);
+    public matchAsgnStmt_9($$dpth: number, $$cr?: ContextRecorder): Nullable<AsgnStmt_9> {
+        return this.matchToradhStmt($$dpth + 1, $$cr);
     }
-    public matchAsgnStmt_10($$dpth: number, cr?: ContextRecorder): Nullable<AsgnStmt_10> {
-        return this.matchAssgnStmt($$dpth + 1, cr);
+    public matchAsgnStmt_10($$dpth: number, $$cr?: ContextRecorder): Nullable<AsgnStmt_10> {
+        return this.matchAssgnStmt($$dpth + 1, $$cr);
     }
-    public matchAsgnStmt_11($$dpth: number, cr?: ContextRecorder): Nullable<AsgnStmt_11> {
-        return this.matchDefnStmt($$dpth + 1, cr);
+    public matchAsgnStmt_11($$dpth: number, $$cr?: ContextRecorder): Nullable<AsgnStmt_11> {
+        return this.matchDefnStmt($$dpth + 1, $$cr);
     }
-    public matchAsgnStmt_12($$dpth: number, cr?: ContextRecorder): Nullable<AsgnStmt_12> {
-        return this.matchExpr($$dpth + 1, cr);
+    public matchAsgnStmt_12($$dpth: number, $$cr?: ContextRecorder): Nullable<AsgnStmt_12> {
+        return this.matchExpr($$dpth + 1, $$cr);
     }
-    public matchNonAsgnStmt($$dpth: number, cr?: ContextRecorder): Nullable<NonAsgnStmt> {
+    public matchNonAsgnStmt($$dpth: number, $$cr?: ContextRecorder): Nullable<NonAsgnStmt> {
         return this.choice<NonAsgnStmt>([
-            () => this.matchNonAsgnStmt_1($$dpth + 1, cr),
-            () => this.matchNonAsgnStmt_2($$dpth + 1, cr),
-            () => this.matchNonAsgnStmt_3($$dpth + 1, cr),
-            () => this.matchNonAsgnStmt_4($$dpth + 1, cr),
-            () => this.matchNonAsgnStmt_5($$dpth + 1, cr),
-            () => this.matchNonAsgnStmt_6($$dpth + 1, cr),
-            () => this.matchNonAsgnStmt_7($$dpth + 1, cr),
-            () => this.matchNonAsgnStmt_8($$dpth + 1, cr),
-            () => this.matchNonAsgnStmt_9($$dpth + 1, cr),
+            () => this.matchNonAsgnStmt_1($$dpth + 1, $$cr),
+            () => this.matchNonAsgnStmt_2($$dpth + 1, $$cr),
+            () => this.matchNonAsgnStmt_3($$dpth + 1, $$cr),
+            () => this.matchNonAsgnStmt_4($$dpth + 1, $$cr),
+            () => this.matchNonAsgnStmt_5($$dpth + 1, $$cr),
+            () => this.matchNonAsgnStmt_6($$dpth + 1, $$cr),
+            () => this.matchNonAsgnStmt_7($$dpth + 1, $$cr),
+            () => this.matchNonAsgnStmt_8($$dpth + 1, $$cr),
+            () => this.matchNonAsgnStmt_9($$dpth + 1, $$cr),
         ]);
     }
-    public matchNonAsgnStmt_1($$dpth: number, cr?: ContextRecorder): Nullable<NonAsgnStmt_1> {
-        return this.matchIfStmt($$dpth + 1, cr);
+    public matchNonAsgnStmt_1($$dpth: number, $$cr?: ContextRecorder): Nullable<NonAsgnStmt_1> {
+        return this.matchIfStmt($$dpth + 1, $$cr);
     }
-    public matchNonAsgnStmt_2($$dpth: number, cr?: ContextRecorder): Nullable<NonAsgnStmt_2> {
-        return this.matchNuairStmt($$dpth + 1, cr);
+    public matchNonAsgnStmt_2($$dpth: number, $$cr?: ContextRecorder): Nullable<NonAsgnStmt_2> {
+        return this.matchNuairStmt($$dpth + 1, $$cr);
     }
-    public matchNonAsgnStmt_3($$dpth: number, cr?: ContextRecorder): Nullable<NonAsgnStmt_3> {
-        return this.matchLeStmt($$dpth + 1, cr);
+    public matchNonAsgnStmt_3($$dpth: number, $$cr?: ContextRecorder): Nullable<NonAsgnStmt_3> {
+        return this.matchLeStmt($$dpth + 1, $$cr);
     }
-    public matchNonAsgnStmt_4($$dpth: number, cr?: ContextRecorder): Nullable<NonAsgnStmt_4> {
-        return this.matchCCStmt($$dpth + 1, cr);
+    public matchNonAsgnStmt_4($$dpth: number, $$cr?: ContextRecorder): Nullable<NonAsgnStmt_4> {
+        return this.matchCCStmt($$dpth + 1, $$cr);
     }
-    public matchNonAsgnStmt_5($$dpth: number, cr?: ContextRecorder): Nullable<NonAsgnStmt_5> {
-        return this.matchBrisStmt($$dpth + 1, cr);
+    public matchNonAsgnStmt_5($$dpth: number, $$cr?: ContextRecorder): Nullable<NonAsgnStmt_5> {
+        return this.matchBrisStmt($$dpth + 1, $$cr);
     }
-    public matchNonAsgnStmt_6($$dpth: number, cr?: ContextRecorder): Nullable<NonAsgnStmt_6> {
-        return this.matchToradhStmt($$dpth + 1, cr);
+    public matchNonAsgnStmt_6($$dpth: number, $$cr?: ContextRecorder): Nullable<NonAsgnStmt_6> {
+        return this.matchToradhStmt($$dpth + 1, $$cr);
     }
-    public matchNonAsgnStmt_7($$dpth: number, cr?: ContextRecorder): Nullable<NonAsgnStmt_7> {
-        return this.matchBlockStmt($$dpth + 1, cr);
+    public matchNonAsgnStmt_7($$dpth: number, $$cr?: ContextRecorder): Nullable<NonAsgnStmt_7> {
+        return this.matchBlockStmt($$dpth + 1, $$cr);
     }
-    public matchNonAsgnStmt_8($$dpth: number, cr?: ContextRecorder): Nullable<NonAsgnStmt_8> {
-        return this.matchAssgnStmt($$dpth + 1, cr);
+    public matchNonAsgnStmt_8($$dpth: number, $$cr?: ContextRecorder): Nullable<NonAsgnStmt_8> {
+        return this.matchAssgnStmt($$dpth + 1, $$cr);
     }
-    public matchNonAsgnStmt_9($$dpth: number, cr?: ContextRecorder): Nullable<NonAsgnStmt_9> {
-        return this.matchExpr($$dpth + 1, cr);
+    public matchNonAsgnStmt_9($$dpth: number, $$cr?: ContextRecorder): Nullable<NonAsgnStmt_9> {
+        return this.matchExpr($$dpth + 1, $$cr);
     }
-    public matchIfStmt($$dpth: number, cr?: ContextRecorder): Nullable<IfStmt> {
+    public matchIfStmt($$dpth: number, $$cr?: ContextRecorder): Nullable<IfStmt> {
         return this.runner<IfStmt>($$dpth,
             (log) => {
                 if (log) {
                     log("IfStmt");
                 }
-                let expr: Nullable<Expr>;
-                let stmt: Nullable<NonAsgnStmt>;
-                let elsebranch: Nullable<Nullable<IfStmt_$0>>;
-                let res: Nullable<IfStmt> = null;
+                let $scope$expr: Nullable<Expr>;
+                let $scope$stmt: Nullable<NonAsgnStmt>;
+                let $scope$elsebranch: Nullable<Nullable<IfStmt_$0>>;
+                let $$res: Nullable<IfStmt> = null;
                 if (true
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.regexAccept(String.raw`(?:m[áa])`, $$dpth + 1, cr) !== null
-                    && this.noConsume<gap>(() => this.matchgap($$dpth + 1, cr)) !== null
-                    && (expr = this.matchExpr($$dpth + 1, cr)) !== null
-                    && this.noConsume<gap>(() => this.matchgap($$dpth + 1, cr)) !== null
-                    && (stmt = this.matchNonAsgnStmt($$dpth + 1, cr)) !== null
-                    && ((elsebranch = this.matchIfStmt_$0($$dpth + 1, cr)) || true)
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.regexAccept(String.raw`(?:m[áa])`, $$dpth + 1, $$cr) !== null
+                    && this.noConsume<gap>(() => this.matchgap($$dpth + 1, $$cr)) !== null
+                    && ($scope$expr = this.matchExpr($$dpth + 1, $$cr)) !== null
+                    && this.noConsume<gap>(() => this.matchgap($$dpth + 1, $$cr)) !== null
+                    && ($scope$stmt = this.matchNonAsgnStmt($$dpth + 1, $$cr)) !== null
+                    && (($scope$elsebranch = this.matchIfStmt_$0($$dpth + 1, $$cr)) || true)
                 ) {
-                    res = {kind: ASTKinds.IfStmt, expr, stmt, elsebranch};
+                    $$res = {kind: ASTKinds.IfStmt, expr: $scope$expr, stmt: $scope$stmt, elsebranch: $scope$elsebranch};
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchIfStmt_$0($$dpth: number, cr?: ContextRecorder): Nullable<IfStmt_$0> {
+    public matchIfStmt_$0($$dpth: number, $$cr?: ContextRecorder): Nullable<IfStmt_$0> {
         return this.runner<IfStmt_$0>($$dpth,
             (log) => {
                 if (log) {
                     log("IfStmt_$0");
                 }
-                let stmt: Nullable<NonAsgnStmt>;
-                let res: Nullable<IfStmt_$0> = null;
+                let $scope$stmt: Nullable<NonAsgnStmt>;
+                let $$res: Nullable<IfStmt_$0> = null;
                 if (true
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.regexAccept(String.raw`(?:n[oó])`, $$dpth + 1, cr) !== null
-                    && this.noConsume<gap>(() => this.matchgap($$dpth + 1, cr)) !== null
-                    && (stmt = this.matchNonAsgnStmt($$dpth + 1, cr)) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.regexAccept(String.raw`(?:n[oó])`, $$dpth + 1, $$cr) !== null
+                    && this.noConsume<gap>(() => this.matchgap($$dpth + 1, $$cr)) !== null
+                    && ($scope$stmt = this.matchNonAsgnStmt($$dpth + 1, $$cr)) !== null
                 ) {
-                    res = {kind: ASTKinds.IfStmt_$0, stmt};
+                    $$res = {kind: ASTKinds.IfStmt_$0, stmt: $scope$stmt};
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchBlockStmt($$dpth: number, cr?: ContextRecorder): Nullable<BlockStmt> {
+    public matchBlockStmt($$dpth: number, $$cr?: ContextRecorder): Nullable<BlockStmt> {
         return this.runner<BlockStmt>($$dpth,
             (log) => {
                 if (log) {
                     log("BlockStmt");
                 }
-                let blk: Nullable<AsgnStmt[]>;
-                let res: Nullable<BlockStmt> = null;
+                let $scope$blk: Nullable<AsgnStmt[]>;
+                let $$res: Nullable<BlockStmt> = null;
                 if (true
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.regexAccept(String.raw`(?:{)`, $$dpth + 1, cr) !== null
-                    && (blk = this.loop<AsgnStmt>(() => this.matchAsgnStmt($$dpth + 1, cr), true)) !== null
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.regexAccept(String.raw`(?:})`, $$dpth + 1, cr) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.regexAccept(String.raw`(?:{)`, $$dpth + 1, $$cr) !== null
+                    && ($scope$blk = this.loop<AsgnStmt>(() => this.matchAsgnStmt($$dpth + 1, $$cr), true)) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.regexAccept(String.raw`(?:})`, $$dpth + 1, $$cr) !== null
                 ) {
-                    res = {kind: ASTKinds.BlockStmt, blk};
+                    $$res = {kind: ASTKinds.BlockStmt, blk: $scope$blk};
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchNuairStmt($$dpth: number, cr?: ContextRecorder): Nullable<NuairStmt> {
+    public matchNuairStmt($$dpth: number, $$cr?: ContextRecorder): Nullable<NuairStmt> {
         return this.runner<NuairStmt>($$dpth,
             (log) => {
                 if (log) {
                     log("NuairStmt");
                 }
-                let expr: Nullable<Expr>;
-                let stmt: Nullable<NonAsgnStmt>;
-                let res: Nullable<NuairStmt> = null;
+                let $scope$expr: Nullable<Expr>;
+                let $scope$stmt: Nullable<NonAsgnStmt>;
+                let $$res: Nullable<NuairStmt> = null;
                 if (true
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.regexAccept(String.raw`(?:nuair-a)`, $$dpth + 1, cr) !== null
-                    && (expr = this.matchExpr($$dpth + 1, cr)) !== null
-                    && this.noConsume<gap>(() => this.matchgap($$dpth + 1, cr)) !== null
-                    && (stmt = this.matchNonAsgnStmt($$dpth + 1, cr)) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.regexAccept(String.raw`(?:nuair-a)`, $$dpth + 1, $$cr) !== null
+                    && ($scope$expr = this.matchExpr($$dpth + 1, $$cr)) !== null
+                    && this.noConsume<gap>(() => this.matchgap($$dpth + 1, $$cr)) !== null
+                    && ($scope$stmt = this.matchNonAsgnStmt($$dpth + 1, $$cr)) !== null
                 ) {
-                    res = {kind: ASTKinds.NuairStmt, expr, stmt};
+                    $$res = {kind: ASTKinds.NuairStmt, expr: $scope$expr, stmt: $scope$stmt};
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchLeStmt($$dpth: number, cr?: ContextRecorder): Nullable<LeStmt> {
+    public matchLeStmt($$dpth: number, $$cr?: ContextRecorder): Nullable<LeStmt> {
         return this.runner<LeStmt>($$dpth,
             (log) => {
                 if (log) {
                     log("LeStmt");
                 }
-                let id: Nullable<ID>;
-                let strt: Nullable<Expr>;
-                let end: Nullable<Expr>;
-                let step: Nullable<Nullable<LeStmt_$0>>;
-                let stmt: Nullable<NonAsgnStmt>;
-                let res: Nullable<LeStmt> = null;
+                let $scope$id: Nullable<ID>;
+                let $scope$strt: Nullable<Expr>;
+                let $scope$end: Nullable<Expr>;
+                let $scope$step: Nullable<Nullable<LeStmt_$0>>;
+                let $scope$stmt: Nullable<NonAsgnStmt>;
+                let $$res: Nullable<LeStmt> = null;
                 if (true
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.regexAccept(String.raw`(?:le)`, $$dpth + 1, cr) !== null
-                    && this.noConsume<gap>(() => this.matchgap($$dpth + 1, cr)) !== null
-                    && (id = this.matchID($$dpth + 1, cr)) !== null
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.regexAccept(String.raw`(?:idir)`, $$dpth + 1, cr) !== null
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.regexAccept(String.raw`(?:\()`, $$dpth + 1, cr) !== null
-                    && (strt = this.matchExpr($$dpth + 1, cr)) !== null
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.regexAccept(String.raw`(?:,)`, $$dpth + 1, cr) !== null
-                    && (end = this.matchExpr($$dpth + 1, cr)) !== null
-                    && ((step = this.matchLeStmt_$0($$dpth + 1, cr)) || true)
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.regexAccept(String.raw`(?:\))`, $$dpth + 1, cr) !== null
-                    && (stmt = this.matchNonAsgnStmt($$dpth + 1, cr)) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.regexAccept(String.raw`(?:le)`, $$dpth + 1, $$cr) !== null
+                    && this.noConsume<gap>(() => this.matchgap($$dpth + 1, $$cr)) !== null
+                    && ($scope$id = this.matchID($$dpth + 1, $$cr)) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.regexAccept(String.raw`(?:idir)`, $$dpth + 1, $$cr) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.regexAccept(String.raw`(?:\()`, $$dpth + 1, $$cr) !== null
+                    && ($scope$strt = this.matchExpr($$dpth + 1, $$cr)) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.regexAccept(String.raw`(?:,)`, $$dpth + 1, $$cr) !== null
+                    && ($scope$end = this.matchExpr($$dpth + 1, $$cr)) !== null
+                    && (($scope$step = this.matchLeStmt_$0($$dpth + 1, $$cr)) || true)
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.regexAccept(String.raw`(?:\))`, $$dpth + 1, $$cr) !== null
+                    && ($scope$stmt = this.matchNonAsgnStmt($$dpth + 1, $$cr)) !== null
                 ) {
-                    res = {kind: ASTKinds.LeStmt, id, strt, end, step, stmt};
+                    $$res = {kind: ASTKinds.LeStmt, id: $scope$id, strt: $scope$strt, end: $scope$end, step: $scope$step, stmt: $scope$stmt};
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchLeStmt_$0($$dpth: number, cr?: ContextRecorder): Nullable<LeStmt_$0> {
+    public matchLeStmt_$0($$dpth: number, $$cr?: ContextRecorder): Nullable<LeStmt_$0> {
         return this.runner<LeStmt_$0>($$dpth,
             (log) => {
                 if (log) {
                     log("LeStmt_$0");
                 }
-                let step: Nullable<Expr>;
-                let res: Nullable<LeStmt_$0> = null;
+                let $scope$step: Nullable<Expr>;
+                let $$res: Nullable<LeStmt_$0> = null;
                 if (true
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.regexAccept(String.raw`(?:,)`, $$dpth + 1, cr) !== null
-                    && (step = this.matchExpr($$dpth + 1, cr)) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.regexAccept(String.raw`(?:,)`, $$dpth + 1, $$cr) !== null
+                    && ($scope$step = this.matchExpr($$dpth + 1, $$cr)) !== null
                 ) {
-                    res = {kind: ASTKinds.LeStmt_$0, step};
+                    $$res = {kind: ASTKinds.LeStmt_$0, step: $scope$step};
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchDefnStmt($$dpth: number, cr?: ContextRecorder): Nullable<DefnStmt> {
+    public matchDefnStmt($$dpth: number, $$cr?: ContextRecorder): Nullable<DefnStmt> {
         return this.runner<DefnStmt>($$dpth,
             (log) => {
                 if (log) {
                     log("DefnStmt");
                 }
-                let id: Nullable<ID>;
-                let expr: Nullable<Expr>;
-                let res: Nullable<DefnStmt> = null;
+                let $scope$id: Nullable<ID>;
+                let $scope$expr: Nullable<Expr>;
+                let $$res: Nullable<DefnStmt> = null;
                 if (true
-                    && this.match_($$dpth + 1, cr) !== null
-                    && (id = this.matchID($$dpth + 1, cr)) !== null
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.regexAccept(String.raw`(?::=)`, $$dpth + 1, cr) !== null
-                    && this.match_($$dpth + 1, cr) !== null
-                    && (expr = this.matchExpr($$dpth + 1, cr)) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && ($scope$id = this.matchID($$dpth + 1, $$cr)) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.regexAccept(String.raw`(?::=)`, $$dpth + 1, $$cr) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && ($scope$expr = this.matchExpr($$dpth + 1, $$cr)) !== null
                 ) {
-                    res = {kind: ASTKinds.DefnStmt, id, expr};
+                    $$res = {kind: ASTKinds.DefnStmt, id: $scope$id, expr: $scope$expr};
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchAssgnStmt($$dpth: number, cr?: ContextRecorder): Nullable<AssgnStmt> {
+    public matchAssgnStmt($$dpth: number, $$cr?: ContextRecorder): Nullable<AssgnStmt> {
         return this.runner<AssgnStmt>($$dpth,
             (log) => {
                 if (log) {
                     log("AssgnStmt");
                 }
-                let lhs: Nullable<Postfix>;
-                let op: Nullable<AsgnOp>;
-                let expr: Nullable<Expr>;
-                let res: Nullable<AssgnStmt> = null;
+                let $scope$lhs: Nullable<Postfix>;
+                let $scope$op: Nullable<AsgnOp>;
+                let $scope$expr: Nullable<Expr>;
+                let $$res: Nullable<AssgnStmt> = null;
                 if (true
-                    && this.match_($$dpth + 1, cr) !== null
-                    && (lhs = this.matchPostfix($$dpth + 1, cr)) !== null
-                    && this.match_($$dpth + 1, cr) !== null
-                    && (op = this.matchAsgnOp($$dpth + 1, cr)) !== null
-                    && this.match_($$dpth + 1, cr) !== null
-                    && (expr = this.matchExpr($$dpth + 1, cr)) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && ($scope$lhs = this.matchPostfix($$dpth + 1, $$cr)) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && ($scope$op = this.matchAsgnOp($$dpth + 1, $$cr)) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && ($scope$expr = this.matchExpr($$dpth + 1, $$cr)) !== null
                 ) {
-                    res = {kind: ASTKinds.AssgnStmt, lhs, op, expr};
+                    $$res = {kind: ASTKinds.AssgnStmt, lhs: $scope$lhs, op: $scope$op, expr: $scope$expr};
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchGniomhStmt($$dpth: number, cr?: ContextRecorder): Nullable<GniomhStmt> {
+    public matchGniomhStmt($$dpth: number, $$cr?: ContextRecorder): Nullable<GniomhStmt> {
         return this.runner<GniomhStmt>($$dpth,
             (log) => {
                 if (log) {
                     log("GniomhStmt");
                 }
-                let id: Nullable<ID>;
-                let args: Nullable<Nullable<CSIDs>>;
-                let stmts: Nullable<AsgnStmt[]>;
-                let res: Nullable<GniomhStmt> = null;
+                let $scope$id: Nullable<ID>;
+                let $scope$args: Nullable<Nullable<CSIDs>>;
+                let $scope$stmts: Nullable<AsgnStmt[]>;
+                let $$res: Nullable<GniomhStmt> = null;
                 if (true
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.regexAccept(String.raw`(?:gn[íi]omh)`, $$dpth + 1, cr) !== null
-                    && this.noConsume<gap>(() => this.matchgap($$dpth + 1, cr)) !== null
-                    && (id = this.matchID($$dpth + 1, cr)) !== null
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.regexAccept(String.raw`(?:\()`, $$dpth + 1, cr) !== null
-                    && ((args = this.matchCSIDs($$dpth + 1, cr)) || true)
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.regexAccept(String.raw`(?:\))`, $$dpth + 1, cr) !== null
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.regexAccept(String.raw`(?:{)`, $$dpth + 1, cr) !== null
-                    && (stmts = this.loop<AsgnStmt>(() => this.matchAsgnStmt($$dpth + 1, cr), true)) !== null
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.regexAccept(String.raw`(?:})`, $$dpth + 1, cr) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.regexAccept(String.raw`(?:gn[íi]omh)`, $$dpth + 1, $$cr) !== null
+                    && this.noConsume<gap>(() => this.matchgap($$dpth + 1, $$cr)) !== null
+                    && ($scope$id = this.matchID($$dpth + 1, $$cr)) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.regexAccept(String.raw`(?:\()`, $$dpth + 1, $$cr) !== null
+                    && (($scope$args = this.matchCSIDs($$dpth + 1, $$cr)) || true)
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.regexAccept(String.raw`(?:\))`, $$dpth + 1, $$cr) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.regexAccept(String.raw`(?:{)`, $$dpth + 1, $$cr) !== null
+                    && ($scope$stmts = this.loop<AsgnStmt>(() => this.matchAsgnStmt($$dpth + 1, $$cr), true)) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.regexAccept(String.raw`(?:})`, $$dpth + 1, $$cr) !== null
                 ) {
-                    res = {kind: ASTKinds.GniomhStmt, id, args, stmts};
+                    $$res = {kind: ASTKinds.GniomhStmt, id: $scope$id, args: $scope$args, stmts: $scope$stmts};
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchCtlchStmt($$dpth: number, cr?: ContextRecorder): Nullable<CtlchStmt> {
+    public matchCtlchStmt($$dpth: number, $$cr?: ContextRecorder): Nullable<CtlchStmt> {
         return this.runner<CtlchStmt>($$dpth,
             (log) => {
                 if (log) {
                     log("CtlchStmt");
                 }
-                let id: Nullable<ID>;
-                let tuis: Nullable<Nullable<CtlchStmt_$0>>;
-                let gniomhs: Nullable<GniomhStmt[]>;
-                let res: Nullable<CtlchStmt> = null;
+                let $scope$id: Nullable<ID>;
+                let $scope$tuis: Nullable<Nullable<CtlchStmt_$0>>;
+                let $scope$gniomhs: Nullable<GniomhStmt[]>;
+                let $$res: Nullable<CtlchStmt> = null;
                 if (true
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.regexAccept(String.raw`(?:creatlach)`, $$dpth + 1, cr) !== null
-                    && this.noConsume<gap>(() => this.matchgap($$dpth + 1, cr)) !== null
-                    && (id = this.matchID($$dpth + 1, cr)) !== null
-                    && ((tuis = this.matchCtlchStmt_$0($$dpth + 1, cr)) || true)
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.regexAccept(String.raw`(?:{)`, $$dpth + 1, cr) !== null
-                    && (gniomhs = this.loop<GniomhStmt>(() => this.matchGniomhStmt($$dpth + 1, cr), true)) !== null
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.regexAccept(String.raw`(?:})`, $$dpth + 1, cr) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.regexAccept(String.raw`(?:creatlach)`, $$dpth + 1, $$cr) !== null
+                    && this.noConsume<gap>(() => this.matchgap($$dpth + 1, $$cr)) !== null
+                    && ($scope$id = this.matchID($$dpth + 1, $$cr)) !== null
+                    && (($scope$tuis = this.matchCtlchStmt_$0($$dpth + 1, $$cr)) || true)
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.regexAccept(String.raw`(?:{)`, $$dpth + 1, $$cr) !== null
+                    && ($scope$gniomhs = this.loop<GniomhStmt>(() => this.matchGniomhStmt($$dpth + 1, $$cr), true)) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.regexAccept(String.raw`(?:})`, $$dpth + 1, $$cr) !== null
                 ) {
-                    res = {kind: ASTKinds.CtlchStmt, id, tuis, gniomhs};
+                    $$res = {kind: ASTKinds.CtlchStmt, id: $scope$id, tuis: $scope$tuis, gniomhs: $scope$gniomhs};
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchCtlchStmt_$0($$dpth: number, cr?: ContextRecorder): Nullable<CtlchStmt_$0> {
+    public matchCtlchStmt_$0($$dpth: number, $$cr?: ContextRecorder): Nullable<CtlchStmt_$0> {
         return this.runner<CtlchStmt_$0>($$dpth,
             (log) => {
                 if (log) {
                     log("CtlchStmt_$0");
                 }
-                let id: Nullable<ID>;
-                let res: Nullable<CtlchStmt_$0> = null;
+                let $scope$id: Nullable<ID>;
+                let $$res: Nullable<CtlchStmt_$0> = null;
                 if (true
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.regexAccept(String.raw`(?:ó)`, $$dpth + 1, cr) !== null
-                    && this.noConsume<gap>(() => this.matchgap($$dpth + 1, cr)) !== null
-                    && (id = this.matchID($$dpth + 1, cr)) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.regexAccept(String.raw`(?:ó)`, $$dpth + 1, $$cr) !== null
+                    && this.noConsume<gap>(() => this.matchgap($$dpth + 1, $$cr)) !== null
+                    && ($scope$id = this.matchID($$dpth + 1, $$cr)) !== null
                 ) {
-                    res = {kind: ASTKinds.CtlchStmt_$0, id};
+                    $$res = {kind: ASTKinds.CtlchStmt_$0, id: $scope$id};
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchBrisStmt($$dpth: number, cr?: ContextRecorder): Nullable<BrisStmt> {
+    public matchBrisStmt($$dpth: number, $$cr?: ContextRecorder): Nullable<BrisStmt> {
         return this.runner<BrisStmt>($$dpth,
             (log) => {
                 if (log) {
                     log("BrisStmt");
                 }
-                let res: Nullable<BrisStmt> = null;
+                let $$res: Nullable<BrisStmt> = null;
                 if (true
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.regexAccept(String.raw`(?:bris)`, $$dpth + 1, cr) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.regexAccept(String.raw`(?:bris)`, $$dpth + 1, $$cr) !== null
                 ) {
-                    res = {kind: ASTKinds.BrisStmt, };
+                    $$res = {kind: ASTKinds.BrisStmt, };
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchCCStmt($$dpth: number, cr?: ContextRecorder): Nullable<CCStmt> {
+    public matchCCStmt($$dpth: number, $$cr?: ContextRecorder): Nullable<CCStmt> {
         return this.runner<CCStmt>($$dpth,
             (log) => {
                 if (log) {
                     log("CCStmt");
                 }
-                let res: Nullable<CCStmt> = null;
+                let $$res: Nullable<CCStmt> = null;
                 if (true
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.regexAccept(String.raw`(?:chun-cinn)`, $$dpth + 1, cr) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.regexAccept(String.raw`(?:chun-cinn)`, $$dpth + 1, $$cr) !== null
                 ) {
-                    res = {kind: ASTKinds.CCStmt, };
+                    $$res = {kind: ASTKinds.CCStmt, };
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchToradhStmt($$dpth: number, cr?: ContextRecorder): Nullable<ToradhStmt> {
+    public matchToradhStmt($$dpth: number, $$cr?: ContextRecorder): Nullable<ToradhStmt> {
         return this.runner<ToradhStmt>($$dpth,
             (log) => {
                 if (log) {
                     log("ToradhStmt");
                 }
-                let exp: Nullable<Nullable<Expr>>;
-                let res: Nullable<ToradhStmt> = null;
+                let $scope$exp: Nullable<Nullable<Expr>>;
+                let $$res: Nullable<ToradhStmt> = null;
                 if (true
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.regexAccept(String.raw`(?:toradh)`, $$dpth + 1, cr) !== null
-                    && this.noConsume<gap>(() => this.matchgap($$dpth + 1, cr)) !== null
-                    && ((exp = this.matchExpr($$dpth + 1, cr)) || true)
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.regexAccept(String.raw`(?:toradh)`, $$dpth + 1, $$cr) !== null
+                    && this.noConsume<gap>(() => this.matchgap($$dpth + 1, $$cr)) !== null
+                    && (($scope$exp = this.matchExpr($$dpth + 1, $$cr)) || true)
                 ) {
-                    res = {kind: ASTKinds.ToradhStmt, exp};
+                    $$res = {kind: ASTKinds.ToradhStmt, exp: $scope$exp};
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchExpr($$dpth: number, cr?: ContextRecorder): Nullable<Expr> {
-        return this.matchAnd($$dpth + 1, cr);
+    public matchExpr($$dpth: number, $$cr?: ContextRecorder): Nullable<Expr> {
+        return this.matchAnd($$dpth + 1, $$cr);
     }
-    public matchAnd($$dpth: number, cr?: ContextRecorder): Nullable<And> {
+    public matchAnd($$dpth: number, $$cr?: ContextRecorder): Nullable<And> {
         return this.runner<And>($$dpth,
             (log) => {
                 if (log) {
                     log("And");
                 }
-                let head: Nullable<Or>;
-                let tail: Nullable<And_$0[]>;
-                let res: Nullable<And> = null;
+                let $scope$head: Nullable<Or>;
+                let $scope$tail: Nullable<And_$0[]>;
+                let $$res: Nullable<And> = null;
                 if (true
-                    && (head = this.matchOr($$dpth + 1, cr)) !== null
-                    && (tail = this.loop<And_$0>(() => this.matchAnd_$0($$dpth + 1, cr), true)) !== null
+                    && ($scope$head = this.matchOr($$dpth + 1, $$cr)) !== null
+                    && ($scope$tail = this.loop<And_$0>(() => this.matchAnd_$0($$dpth + 1, $$cr), true)) !== null
                 ) {
-                    res = {kind: ASTKinds.And, head, tail};
+                    $$res = {kind: ASTKinds.And, head: $scope$head, tail: $scope$tail};
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchAnd_$0($$dpth: number, cr?: ContextRecorder): Nullable<And_$0> {
+    public matchAnd_$0($$dpth: number, $$cr?: ContextRecorder): Nullable<And_$0> {
         return this.runner<And_$0>($$dpth,
             (log) => {
                 if (log) {
                     log("And_$0");
                 }
-                let trm: Nullable<Or>;
-                let res: Nullable<And_$0> = null;
+                let $scope$trm: Nullable<Or>;
+                let $$res: Nullable<And_$0> = null;
                 if (true
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.regexAccept(String.raw`(?:\&)`, $$dpth + 1, cr) !== null
-                    && (trm = this.matchOr($$dpth + 1, cr)) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.regexAccept(String.raw`(?:\&)`, $$dpth + 1, $$cr) !== null
+                    && ($scope$trm = this.matchOr($$dpth + 1, $$cr)) !== null
                 ) {
-                    res = {kind: ASTKinds.And_$0, trm};
+                    $$res = {kind: ASTKinds.And_$0, trm: $scope$trm};
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchOr($$dpth: number, cr?: ContextRecorder): Nullable<Or> {
+    public matchOr($$dpth: number, $$cr?: ContextRecorder): Nullable<Or> {
         return this.runner<Or>($$dpth,
             (log) => {
                 if (log) {
                     log("Or");
                 }
-                let head: Nullable<Eq>;
-                let tail: Nullable<Or_$0[]>;
-                let res: Nullable<Or> = null;
+                let $scope$head: Nullable<Eq>;
+                let $scope$tail: Nullable<Or_$0[]>;
+                let $$res: Nullable<Or> = null;
                 if (true
-                    && (head = this.matchEq($$dpth + 1, cr)) !== null
-                    && (tail = this.loop<Or_$0>(() => this.matchOr_$0($$dpth + 1, cr), true)) !== null
+                    && ($scope$head = this.matchEq($$dpth + 1, $$cr)) !== null
+                    && ($scope$tail = this.loop<Or_$0>(() => this.matchOr_$0($$dpth + 1, $$cr), true)) !== null
                 ) {
-                    res = {kind: ASTKinds.Or, head, tail};
+                    $$res = {kind: ASTKinds.Or, head: $scope$head, tail: $scope$tail};
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchOr_$0($$dpth: number, cr?: ContextRecorder): Nullable<Or_$0> {
+    public matchOr_$0($$dpth: number, $$cr?: ContextRecorder): Nullable<Or_$0> {
         return this.runner<Or_$0>($$dpth,
             (log) => {
                 if (log) {
                     log("Or_$0");
                 }
-                let trm: Nullable<Eq>;
-                let res: Nullable<Or_$0> = null;
+                let $scope$trm: Nullable<Eq>;
+                let $$res: Nullable<Or_$0> = null;
                 if (true
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.regexAccept(String.raw`(?:\|)`, $$dpth + 1, cr) !== null
-                    && (trm = this.matchEq($$dpth + 1, cr)) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.regexAccept(String.raw`(?:\|)`, $$dpth + 1, $$cr) !== null
+                    && ($scope$trm = this.matchEq($$dpth + 1, $$cr)) !== null
                 ) {
-                    res = {kind: ASTKinds.Or_$0, trm};
+                    $$res = {kind: ASTKinds.Or_$0, trm: $scope$trm};
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchEq($$dpth: number, cr?: ContextRecorder): Nullable<Eq> {
+    public matchEq($$dpth: number, $$cr?: ContextRecorder): Nullable<Eq> {
         return this.runner<Eq>($$dpth,
             (log) => {
                 if (log) {
                     log("Eq");
                 }
-                let head: Nullable<Comp>;
-                let tail: Nullable<Eq_$0[]>;
-                let res: Nullable<Eq> = null;
+                let $scope$head: Nullable<Comp>;
+                let $scope$tail: Nullable<Eq_$0[]>;
+                let $$res: Nullable<Eq> = null;
                 if (true
-                    && (head = this.matchComp($$dpth + 1, cr)) !== null
-                    && (tail = this.loop<Eq_$0>(() => this.matchEq_$0($$dpth + 1, cr), true)) !== null
+                    && ($scope$head = this.matchComp($$dpth + 1, $$cr)) !== null
+                    && ($scope$tail = this.loop<Eq_$0>(() => this.matchEq_$0($$dpth + 1, $$cr), true)) !== null
                 ) {
-                    res = {kind: ASTKinds.Eq, head, tail};
+                    $$res = {kind: ASTKinds.Eq, head: $scope$head, tail: $scope$tail};
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchEq_$0($$dpth: number, cr?: ContextRecorder): Nullable<Eq_$0> {
+    public matchEq_$0($$dpth: number, $$cr?: ContextRecorder): Nullable<Eq_$0> {
         return this.runner<Eq_$0>($$dpth,
             (log) => {
                 if (log) {
                     log("Eq_$0");
                 }
-                let op: Nullable<string>;
-                let trm: Nullable<Comp>;
-                let res: Nullable<Eq_$0> = null;
+                let $scope$op: Nullable<string>;
+                let $scope$trm: Nullable<Comp>;
+                let $$res: Nullable<Eq_$0> = null;
                 if (true
-                    && this.match_($$dpth + 1, cr) !== null
-                    && (op = this.regexAccept(String.raw`(?:[!=]=)`, $$dpth + 1, cr)) !== null
-                    && (trm = this.matchComp($$dpth + 1, cr)) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && ($scope$op = this.regexAccept(String.raw`(?:[!=]=)`, $$dpth + 1, $$cr)) !== null
+                    && ($scope$trm = this.matchComp($$dpth + 1, $$cr)) !== null
                 ) {
-                    res = {kind: ASTKinds.Eq_$0, op, trm};
+                    $$res = {kind: ASTKinds.Eq_$0, op: $scope$op, trm: $scope$trm};
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchComp($$dpth: number, cr?: ContextRecorder): Nullable<Comp> {
+    public matchComp($$dpth: number, $$cr?: ContextRecorder): Nullable<Comp> {
         return this.runner<Comp>($$dpth,
             (log) => {
                 if (log) {
                     log("Comp");
                 }
-                let head: Nullable<Sum>;
-                let tail: Nullable<Comp_$0[]>;
-                let res: Nullable<Comp> = null;
+                let $scope$head: Nullable<Sum>;
+                let $scope$tail: Nullable<Comp_$0[]>;
+                let $$res: Nullable<Comp> = null;
                 if (true
-                    && (head = this.matchSum($$dpth + 1, cr)) !== null
-                    && (tail = this.loop<Comp_$0>(() => this.matchComp_$0($$dpth + 1, cr), true)) !== null
+                    && ($scope$head = this.matchSum($$dpth + 1, $$cr)) !== null
+                    && ($scope$tail = this.loop<Comp_$0>(() => this.matchComp_$0($$dpth + 1, $$cr), true)) !== null
                 ) {
-                    res = {kind: ASTKinds.Comp, head, tail};
+                    $$res = {kind: ASTKinds.Comp, head: $scope$head, tail: $scope$tail};
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchComp_$0($$dpth: number, cr?: ContextRecorder): Nullable<Comp_$0> {
+    public matchComp_$0($$dpth: number, $$cr?: ContextRecorder): Nullable<Comp_$0> {
         return this.runner<Comp_$0>($$dpth,
             (log) => {
                 if (log) {
                     log("Comp_$0");
                 }
-                let op: Nullable<Compare>;
-                let trm: Nullable<Sum>;
-                let res: Nullable<Comp_$0> = null;
+                let $scope$op: Nullable<Compare>;
+                let $scope$trm: Nullable<Sum>;
+                let $$res: Nullable<Comp_$0> = null;
                 if (true
-                    && this.match_($$dpth + 1, cr) !== null
-                    && (op = this.matchCompare($$dpth + 1, cr)) !== null
-                    && (trm = this.matchSum($$dpth + 1, cr)) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && ($scope$op = this.matchCompare($$dpth + 1, $$cr)) !== null
+                    && ($scope$trm = this.matchSum($$dpth + 1, $$cr)) !== null
                 ) {
-                    res = {kind: ASTKinds.Comp_$0, op, trm};
+                    $$res = {kind: ASTKinds.Comp_$0, op: $scope$op, trm: $scope$trm};
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchSum($$dpth: number, cr?: ContextRecorder): Nullable<Sum> {
+    public matchSum($$dpth: number, $$cr?: ContextRecorder): Nullable<Sum> {
         return this.runner<Sum>($$dpth,
             (log) => {
                 if (log) {
                     log("Sum");
                 }
-                let head: Nullable<Product>;
-                let tail: Nullable<Sum_$0[]>;
-                let res: Nullable<Sum> = null;
+                let $scope$head: Nullable<Product>;
+                let $scope$tail: Nullable<Sum_$0[]>;
+                let $$res: Nullable<Sum> = null;
                 if (true
-                    && (head = this.matchProduct($$dpth + 1, cr)) !== null
-                    && (tail = this.loop<Sum_$0>(() => this.matchSum_$0($$dpth + 1, cr), true)) !== null
+                    && ($scope$head = this.matchProduct($$dpth + 1, $$cr)) !== null
+                    && ($scope$tail = this.loop<Sum_$0>(() => this.matchSum_$0($$dpth + 1, $$cr), true)) !== null
                 ) {
-                    res = {kind: ASTKinds.Sum, head, tail};
+                    $$res = {kind: ASTKinds.Sum, head: $scope$head, tail: $scope$tail};
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchSum_$0($$dpth: number, cr?: ContextRecorder): Nullable<Sum_$0> {
+    public matchSum_$0($$dpth: number, $$cr?: ContextRecorder): Nullable<Sum_$0> {
         return this.runner<Sum_$0>($$dpth,
             (log) => {
                 if (log) {
                     log("Sum_$0");
                 }
-                let op: Nullable<PlusMinus>;
-                let trm: Nullable<Product>;
-                let res: Nullable<Sum_$0> = null;
+                let $scope$op: Nullable<PlusMinus>;
+                let $scope$trm: Nullable<Product>;
+                let $$res: Nullable<Sum_$0> = null;
                 if (true
-                    && this.match_($$dpth + 1, cr) !== null
-                    && (op = this.matchPlusMinus($$dpth + 1, cr)) !== null
-                    && (trm = this.matchProduct($$dpth + 1, cr)) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && ($scope$op = this.matchPlusMinus($$dpth + 1, $$cr)) !== null
+                    && ($scope$trm = this.matchProduct($$dpth + 1, $$cr)) !== null
                 ) {
-                    res = {kind: ASTKinds.Sum_$0, op, trm};
+                    $$res = {kind: ASTKinds.Sum_$0, op: $scope$op, trm: $scope$trm};
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchProduct($$dpth: number, cr?: ContextRecorder): Nullable<Product> {
+    public matchProduct($$dpth: number, $$cr?: ContextRecorder): Nullable<Product> {
         return this.runner<Product>($$dpth,
             (log) => {
                 if (log) {
                     log("Product");
                 }
-                let head: Nullable<Prefix>;
-                let tail: Nullable<Product_$0[]>;
-                let res: Nullable<Product> = null;
+                let $scope$head: Nullable<Prefix>;
+                let $scope$tail: Nullable<Product_$0[]>;
+                let $$res: Nullable<Product> = null;
                 if (true
-                    && (head = this.matchPrefix($$dpth + 1, cr)) !== null
-                    && (tail = this.loop<Product_$0>(() => this.matchProduct_$0($$dpth + 1, cr), true)) !== null
+                    && ($scope$head = this.matchPrefix($$dpth + 1, $$cr)) !== null
+                    && ($scope$tail = this.loop<Product_$0>(() => this.matchProduct_$0($$dpth + 1, $$cr), true)) !== null
                 ) {
-                    res = {kind: ASTKinds.Product, head, tail};
+                    $$res = {kind: ASTKinds.Product, head: $scope$head, tail: $scope$tail};
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchProduct_$0($$dpth: number, cr?: ContextRecorder): Nullable<Product_$0> {
+    public matchProduct_$0($$dpth: number, $$cr?: ContextRecorder): Nullable<Product_$0> {
         return this.runner<Product_$0>($$dpth,
             (log) => {
                 if (log) {
                     log("Product_$0");
                 }
-                let op: Nullable<MulDiv>;
-                let trm: Nullable<Prefix>;
-                let res: Nullable<Product_$0> = null;
+                let $scope$op: Nullable<MulDiv>;
+                let $scope$trm: Nullable<Prefix>;
+                let $$res: Nullable<Product_$0> = null;
                 if (true
-                    && this.match_($$dpth + 1, cr) !== null
-                    && (op = this.matchMulDiv($$dpth + 1, cr)) !== null
-                    && (trm = this.matchPrefix($$dpth + 1, cr)) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && ($scope$op = this.matchMulDiv($$dpth + 1, $$cr)) !== null
+                    && ($scope$trm = this.matchPrefix($$dpth + 1, $$cr)) !== null
                 ) {
-                    res = {kind: ASTKinds.Product_$0, op, trm};
+                    $$res = {kind: ASTKinds.Product_$0, op: $scope$op, trm: $scope$trm};
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchPrefix($$dpth: number, cr?: ContextRecorder): Nullable<Prefix> {
+    public matchPrefix($$dpth: number, $$cr?: ContextRecorder): Nullable<Prefix> {
         return this.runner<Prefix>($$dpth,
             (log) => {
                 if (log) {
                     log("Prefix");
                 }
-                let op: Nullable<Nullable<string>>;
-                let pf: Nullable<Postfix>;
-                let res: Nullable<Prefix> = null;
+                let $scope$op: Nullable<Nullable<string>>;
+                let $scope$pf: Nullable<Postfix>;
+                let $$res: Nullable<Prefix> = null;
                 if (true
-                    && this.match_($$dpth + 1, cr) !== null
-                    && ((op = this.regexAccept(String.raw`(?:-|!)`, $$dpth + 1, cr)) || true)
-                    && (pf = this.matchPostfix($$dpth + 1, cr)) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && (($scope$op = this.regexAccept(String.raw`(?:-|!)`, $$dpth + 1, $$cr)) || true)
+                    && ($scope$pf = this.matchPostfix($$dpth + 1, $$cr)) !== null
                 ) {
-                    res = {kind: ASTKinds.Prefix, op, pf};
+                    $$res = {kind: ASTKinds.Prefix, op: $scope$op, pf: $scope$pf};
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchPostfix($$dpth: number, cr?: ContextRecorder): Nullable<Postfix> {
+    public matchPostfix($$dpth: number, $$cr?: ContextRecorder): Nullable<Postfix> {
         return this.runner<Postfix>($$dpth,
             (log) => {
                 if (log) {
                     log("Postfix");
                 }
-                let at: Nullable<ObjLookups>;
-                let ops: Nullable<PostOp[]>;
-                let res: Nullable<Postfix> = null;
+                let $scope$at: Nullable<ObjLookups>;
+                let $scope$ops: Nullable<PostOp[]>;
+                let $$res: Nullable<Postfix> = null;
                 if (true
-                    && (at = this.matchObjLookups($$dpth + 1, cr)) !== null
-                    && (ops = this.loop<PostOp>(() => this.matchPostOp($$dpth + 1, cr), true)) !== null
+                    && ($scope$at = this.matchObjLookups($$dpth + 1, $$cr)) !== null
+                    && ($scope$ops = this.loop<PostOp>(() => this.matchPostOp($$dpth + 1, $$cr), true)) !== null
                 ) {
-                    res = {kind: ASTKinds.Postfix, at, ops};
+                    $$res = {kind: ASTKinds.Postfix, at: $scope$at, ops: $scope$ops};
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchObjLookups($$dpth: number, cr?: ContextRecorder): Nullable<ObjLookups> {
+    public matchObjLookups($$dpth: number, $$cr?: ContextRecorder): Nullable<ObjLookups> {
         return this.runner<ObjLookups>($$dpth,
             (log) => {
                 if (log) {
                     log("ObjLookups");
                 }
-                let attrs: Nullable<ObjLookups_$0[]>;
-                let root: Nullable<Atom>;
-                let res: Nullable<ObjLookups> = null;
+                let $scope$attrs: Nullable<ObjLookups_$0[]>;
+                let $scope$root: Nullable<Atom>;
+                let $$res: Nullable<ObjLookups> = null;
                 if (true
-                    && (attrs = this.loop<ObjLookups_$0>(() => this.matchObjLookups_$0($$dpth + 1, cr), true)) !== null
-                    && (root = this.matchAtom($$dpth + 1, cr)) !== null
+                    && ($scope$attrs = this.loop<ObjLookups_$0>(() => this.matchObjLookups_$0($$dpth + 1, $$cr), true)) !== null
+                    && ($scope$root = this.matchAtom($$dpth + 1, $$cr)) !== null
                 ) {
-                    res = {kind: ASTKinds.ObjLookups, attrs, root};
+                    $$res = {kind: ASTKinds.ObjLookups, attrs: $scope$attrs, root: $scope$root};
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchObjLookups_$0($$dpth: number, cr?: ContextRecorder): Nullable<ObjLookups_$0> {
+    public matchObjLookups_$0($$dpth: number, $$cr?: ContextRecorder): Nullable<ObjLookups_$0> {
         return this.runner<ObjLookups_$0>($$dpth,
             (log) => {
                 if (log) {
                     log("ObjLookups_$0");
                 }
-                let id: Nullable<ID>;
-                let res: Nullable<ObjLookups_$0> = null;
+                let $scope$id: Nullable<ID>;
+                let $$res: Nullable<ObjLookups_$0> = null;
                 if (true
-                    && (id = this.matchID($$dpth + 1, cr)) !== null
-                    && this.regexAccept(String.raw`(?:@)`, $$dpth + 1, cr) !== null
-                    && this.negate(() => this.matchwspace($$dpth + 1, cr)) !== null
+                    && ($scope$id = this.matchID($$dpth + 1, $$cr)) !== null
+                    && this.regexAccept(String.raw`(?:@)`, $$dpth + 1, $$cr) !== null
+                    && this.negate(() => this.matchwspace($$dpth + 1, $$cr)) !== null
                 ) {
-                    res = {kind: ASTKinds.ObjLookups_$0, id};
+                    $$res = {kind: ASTKinds.ObjLookups_$0, id: $scope$id};
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchPostOp($$dpth: number, cr?: ContextRecorder): Nullable<PostOp> {
+    public matchPostOp($$dpth: number, $$cr?: ContextRecorder): Nullable<PostOp> {
         return this.choice<PostOp>([
-            () => this.matchPostOp_1($$dpth + 1, cr),
-            () => this.matchPostOp_2($$dpth + 1, cr),
+            () => this.matchPostOp_1($$dpth + 1, $$cr),
+            () => this.matchPostOp_2($$dpth + 1, $$cr),
         ]);
     }
-    public matchPostOp_1($$dpth: number, cr?: ContextRecorder): Nullable<PostOp_1> {
+    public matchPostOp_1($$dpth: number, $$cr?: ContextRecorder): Nullable<PostOp_1> {
         return this.runner<PostOp_1>($$dpth,
             (log) => {
                 if (log) {
                     log("PostOp_1");
                 }
-                let args: Nullable<Nullable<CSArgs>>;
-                let res: Nullable<PostOp_1> = null;
+                let $scope$args: Nullable<Nullable<CSArgs>>;
+                let $$res: Nullable<PostOp_1> = null;
                 if (true
-                    && this.regexAccept(String.raw`(?:\()`, $$dpth + 1, cr) !== null
-                    && ((args = this.matchCSArgs($$dpth + 1, cr)) || true)
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.regexAccept(String.raw`(?:\))`, $$dpth + 1, cr) !== null
+                    && this.regexAccept(String.raw`(?:\()`, $$dpth + 1, $$cr) !== null
+                    && (($scope$args = this.matchCSArgs($$dpth + 1, $$cr)) || true)
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.regexAccept(String.raw`(?:\))`, $$dpth + 1, $$cr) !== null
                 ) {
-                    res = {kind: ASTKinds.PostOp_1, args};
+                    $$res = {kind: ASTKinds.PostOp_1, args: $scope$args};
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchPostOp_2($$dpth: number, cr?: ContextRecorder): Nullable<PostOp_2> {
+    public matchPostOp_2($$dpth: number, $$cr?: ContextRecorder): Nullable<PostOp_2> {
         return this.runner<PostOp_2>($$dpth,
             (log) => {
                 if (log) {
                     log("PostOp_2");
                 }
-                let expr: Nullable<Expr>;
-                let res: Nullable<PostOp_2> = null;
+                let $scope$expr: Nullable<Expr>;
+                let $$res: Nullable<PostOp_2> = null;
                 if (true
-                    && this.regexAccept(String.raw`(?:\[)`, $$dpth + 1, cr) !== null
-                    && (expr = this.matchExpr($$dpth + 1, cr)) !== null
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.regexAccept(String.raw`(?:\])`, $$dpth + 1, cr) !== null
+                    && this.regexAccept(String.raw`(?:\[)`, $$dpth + 1, $$cr) !== null
+                    && ($scope$expr = this.matchExpr($$dpth + 1, $$cr)) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.regexAccept(String.raw`(?:\])`, $$dpth + 1, $$cr) !== null
                 ) {
-                    res = {kind: ASTKinds.PostOp_2, expr};
+                    $$res = {kind: ASTKinds.PostOp_2, expr: $scope$expr};
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchAtom($$dpth: number, cr?: ContextRecorder): Nullable<Atom> {
+    public matchAtom($$dpth: number, $$cr?: ContextRecorder): Nullable<Atom> {
         return this.choice<Atom>([
-            () => this.matchAtom_1($$dpth + 1, cr),
-            () => this.matchAtom_2($$dpth + 1, cr),
-            () => this.matchAtom_3($$dpth + 1, cr),
-            () => this.matchAtom_4($$dpth + 1, cr),
-            () => this.matchAtom_5($$dpth + 1, cr),
-            () => this.matchAtom_6($$dpth + 1, cr),
-            () => this.matchAtom_7($$dpth + 1, cr),
+            () => this.matchAtom_1($$dpth + 1, $$cr),
+            () => this.matchAtom_2($$dpth + 1, $$cr),
+            () => this.matchAtom_3($$dpth + 1, $$cr),
+            () => this.matchAtom_4($$dpth + 1, $$cr),
+            () => this.matchAtom_5($$dpth + 1, $$cr),
+            () => this.matchAtom_6($$dpth + 1, $$cr),
+            () => this.matchAtom_7($$dpth + 1, $$cr),
         ]);
     }
-    public matchAtom_1($$dpth: number, cr?: ContextRecorder): Nullable<Atom_1> {
+    public matchAtom_1($$dpth: number, $$cr?: ContextRecorder): Nullable<Atom_1> {
         return this.runner<Atom_1>($$dpth,
             (log) => {
                 if (log) {
                     log("Atom_1");
                 }
-                let trm: Nullable<Expr>;
-                let res: Nullable<Atom_1> = null;
+                let $scope$trm: Nullable<Expr>;
+                let $$res: Nullable<Atom_1> = null;
                 if (true
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.regexAccept(String.raw`(?:\()`, $$dpth + 1, cr) !== null
-                    && (trm = this.matchExpr($$dpth + 1, cr)) !== null
-                    && this.regexAccept(String.raw`(?:\))`, $$dpth + 1, cr) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.regexAccept(String.raw`(?:\()`, $$dpth + 1, $$cr) !== null
+                    && ($scope$trm = this.matchExpr($$dpth + 1, $$cr)) !== null
+                    && this.regexAccept(String.raw`(?:\))`, $$dpth + 1, $$cr) !== null
                 ) {
-                    res = {kind: ASTKinds.Atom_1, trm};
+                    $$res = {kind: ASTKinds.Atom_1, trm: $scope$trm};
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchAtom_2($$dpth: number, cr?: ContextRecorder): Nullable<Atom_2> {
-        return this.matchID($$dpth + 1, cr);
+    public matchAtom_2($$dpth: number, $$cr?: ContextRecorder): Nullable<Atom_2> {
+        return this.matchID($$dpth + 1, $$cr);
     }
-    public matchAtom_3($$dpth: number, cr?: ContextRecorder): Nullable<Atom_3> {
-        return this.matchLitreacha($$dpth + 1, cr);
+    public matchAtom_3($$dpth: number, $$cr?: ContextRecorder): Nullable<Atom_3> {
+        return this.matchLitreacha($$dpth + 1, $$cr);
     }
-    public matchAtom_4($$dpth: number, cr?: ContextRecorder): Nullable<Atom_4> {
-        return this.matchInt($$dpth + 1, cr);
+    public matchAtom_4($$dpth: number, $$cr?: ContextRecorder): Nullable<Atom_4> {
+        return this.matchInt($$dpth + 1, $$cr);
     }
-    public matchAtom_5($$dpth: number, cr?: ContextRecorder): Nullable<Atom_5> {
-        return this.matchBool($$dpth + 1, cr);
+    public matchAtom_5($$dpth: number, $$cr?: ContextRecorder): Nullable<Atom_5> {
+        return this.matchBool($$dpth + 1, $$cr);
     }
-    public matchAtom_6($$dpth: number, cr?: ContextRecorder): Nullable<Atom_6> {
-        return this.matchNeamhni($$dpth + 1, cr);
+    public matchAtom_6($$dpth: number, $$cr?: ContextRecorder): Nullable<Atom_6> {
+        return this.matchNeamhni($$dpth + 1, $$cr);
     }
-    public matchAtom_7($$dpth: number, cr?: ContextRecorder): Nullable<Atom_7> {
-        return this.matchListLit($$dpth + 1, cr);
+    public matchAtom_7($$dpth: number, $$cr?: ContextRecorder): Nullable<Atom_7> {
+        return this.matchListLit($$dpth + 1, $$cr);
     }
-    public matchListLit($$dpth: number, cr?: ContextRecorder): Nullable<ListLit> {
+    public matchListLit($$dpth: number, $$cr?: ContextRecorder): Nullable<ListLit> {
         return this.runner<ListLit>($$dpth,
             (log) => {
                 if (log) {
                     log("ListLit");
                 }
-                let els: Nullable<Nullable<CSArgs>>;
-                let res: Nullable<ListLit> = null;
+                let $scope$els: Nullable<Nullable<CSArgs>>;
+                let $$res: Nullable<ListLit> = null;
                 if (true
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.regexAccept(String.raw`(?:\[)`, $$dpth + 1, cr) !== null
-                    && ((els = this.matchCSArgs($$dpth + 1, cr)) || true)
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.regexAccept(String.raw`(?:\])`, $$dpth + 1, cr) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.regexAccept(String.raw`(?:\[)`, $$dpth + 1, $$cr) !== null
+                    && (($scope$els = this.matchCSArgs($$dpth + 1, $$cr)) || true)
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.regexAccept(String.raw`(?:\])`, $$dpth + 1, $$cr) !== null
                 ) {
-                    res = {kind: ASTKinds.ListLit, els};
+                    $$res = {kind: ASTKinds.ListLit, els: $scope$els};
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchCSArgs($$dpth: number, cr?: ContextRecorder): Nullable<CSArgs> {
+    public matchCSArgs($$dpth: number, $$cr?: ContextRecorder): Nullable<CSArgs> {
         return this.runner<CSArgs>($$dpth,
             (log) => {
                 if (log) {
                     log("CSArgs");
                 }
-                let head: Nullable<Expr>;
-                let tail: Nullable<CSArgs_$0[]>;
-                let res: Nullable<CSArgs> = null;
+                let $scope$head: Nullable<Expr>;
+                let $scope$tail: Nullable<CSArgs_$0[]>;
+                let $$res: Nullable<CSArgs> = null;
                 if (true
-                    && (head = this.matchExpr($$dpth + 1, cr)) !== null
-                    && (tail = this.loop<CSArgs_$0>(() => this.matchCSArgs_$0($$dpth + 1, cr), true)) !== null
+                    && ($scope$head = this.matchExpr($$dpth + 1, $$cr)) !== null
+                    && ($scope$tail = this.loop<CSArgs_$0>(() => this.matchCSArgs_$0($$dpth + 1, $$cr), true)) !== null
                 ) {
-                    res = {kind: ASTKinds.CSArgs, head, tail};
+                    $$res = {kind: ASTKinds.CSArgs, head: $scope$head, tail: $scope$tail};
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchCSArgs_$0($$dpth: number, cr?: ContextRecorder): Nullable<CSArgs_$0> {
+    public matchCSArgs_$0($$dpth: number, $$cr?: ContextRecorder): Nullable<CSArgs_$0> {
         return this.runner<CSArgs_$0>($$dpth,
             (log) => {
                 if (log) {
                     log("CSArgs_$0");
                 }
-                let exp: Nullable<Expr>;
-                let res: Nullable<CSArgs_$0> = null;
+                let $scope$exp: Nullable<Expr>;
+                let $$res: Nullable<CSArgs_$0> = null;
                 if (true
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.regexAccept(String.raw`(?:,)`, $$dpth + 1, cr) !== null
-                    && (exp = this.matchExpr($$dpth + 1, cr)) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.regexAccept(String.raw`(?:,)`, $$dpth + 1, $$cr) !== null
+                    && ($scope$exp = this.matchExpr($$dpth + 1, $$cr)) !== null
                 ) {
-                    res = {kind: ASTKinds.CSArgs_$0, exp};
+                    $$res = {kind: ASTKinds.CSArgs_$0, exp: $scope$exp};
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchCSIDs($$dpth: number, cr?: ContextRecorder): Nullable<CSIDs> {
+    public matchCSIDs($$dpth: number, $$cr?: ContextRecorder): Nullable<CSIDs> {
         return this.runner<CSIDs>($$dpth,
             (log) => {
                 if (log) {
                     log("CSIDs");
                 }
-                let head: Nullable<ID>;
-                let tail: Nullable<CSIDs_$0[]>;
-                let res: Nullable<CSIDs> = null;
+                let $scope$head: Nullable<ID>;
+                let $scope$tail: Nullable<CSIDs_$0[]>;
+                let $$res: Nullable<CSIDs> = null;
                 if (true
-                    && (head = this.matchID($$dpth + 1, cr)) !== null
-                    && (tail = this.loop<CSIDs_$0>(() => this.matchCSIDs_$0($$dpth + 1, cr), true)) !== null
+                    && ($scope$head = this.matchID($$dpth + 1, $$cr)) !== null
+                    && ($scope$tail = this.loop<CSIDs_$0>(() => this.matchCSIDs_$0($$dpth + 1, $$cr), true)) !== null
                 ) {
-                    res = {kind: ASTKinds.CSIDs, head, tail};
+                    $$res = {kind: ASTKinds.CSIDs, head: $scope$head, tail: $scope$tail};
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchCSIDs_$0($$dpth: number, cr?: ContextRecorder): Nullable<CSIDs_$0> {
+    public matchCSIDs_$0($$dpth: number, $$cr?: ContextRecorder): Nullable<CSIDs_$0> {
         return this.runner<CSIDs_$0>($$dpth,
             (log) => {
                 if (log) {
                     log("CSIDs_$0");
                 }
-                let id: Nullable<ID>;
-                let res: Nullable<CSIDs_$0> = null;
+                let $scope$id: Nullable<ID>;
+                let $$res: Nullable<CSIDs_$0> = null;
                 if (true
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.regexAccept(String.raw`(?:,)`, $$dpth + 1, cr) !== null
-                    && (id = this.matchID($$dpth + 1, cr)) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.regexAccept(String.raw`(?:,)`, $$dpth + 1, $$cr) !== null
+                    && ($scope$id = this.matchID($$dpth + 1, $$cr)) !== null
                 ) {
-                    res = {kind: ASTKinds.CSIDs_$0, id};
+                    $$res = {kind: ASTKinds.CSIDs_$0, id: $scope$id};
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchID($$dpth: number, cr?: ContextRecorder): Nullable<ID> {
+    public matchID($$dpth: number, $$cr?: ContextRecorder): Nullable<ID> {
         return this.runner<ID>($$dpth,
             (log) => {
                 if (log) {
                     log("ID");
                 }
-                let id: Nullable<string>;
-                let res: Nullable<ID> = null;
+                let $scope$id: Nullable<string>;
+                let $$res: Nullable<ID> = null;
                 if (true
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.negate(() => this.matchID_$0($$dpth + 1, cr)) !== null
-                    && (id = this.regexAccept(String.raw`(?:[a-zA-Z_áéíóúÁÉÍÓÚ]+)`, $$dpth + 1, cr)) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.negate(() => this.matchID_$0($$dpth + 1, $$cr)) !== null
+                    && ($scope$id = this.regexAccept(String.raw`(?:[a-zA-Z_áéíóúÁÉÍÓÚ]+)`, $$dpth + 1, $$cr)) !== null
                 ) {
-                    res = {kind: ASTKinds.ID, id};
+                    $$res = {kind: ASTKinds.ID, id: $scope$id};
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchID_$0($$dpth: number, cr?: ContextRecorder): Nullable<ID_$0> {
+    public matchID_$0($$dpth: number, $$cr?: ContextRecorder): Nullable<ID_$0> {
         return this.runner<ID_$0>($$dpth,
             (log) => {
                 if (log) {
                     log("ID_$0");
                 }
-                let res: Nullable<ID_$0> = null;
+                let $$res: Nullable<ID_$0> = null;
                 if (true
-                    && this.matchKeyword($$dpth + 1, cr) !== null
-                    && this.matchgap($$dpth + 1, cr) !== null
+                    && this.matchKeyword($$dpth + 1, $$cr) !== null
+                    && this.matchgap($$dpth + 1, $$cr) !== null
                 ) {
-                    res = {kind: ASTKinds.ID_$0, };
+                    $$res = {kind: ASTKinds.ID_$0, };
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchBool($$dpth: number, cr?: ContextRecorder): Nullable<Bool> {
+    public matchBool($$dpth: number, $$cr?: ContextRecorder): Nullable<Bool> {
         return this.runner<Bool>($$dpth,
             (log) => {
                 if (log) {
                     log("Bool");
                 }
-                let bool: Nullable<string>;
-                let res: Nullable<Bool> = null;
+                let $scope$bool: Nullable<string>;
+                let $$res: Nullable<Bool> = null;
                 if (true
-                    && this.match_($$dpth + 1, cr) !== null
-                    && (bool = this.regexAccept(String.raw`(?:f[ií]or|br[eé]ag)`, $$dpth + 1, cr)) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && ($scope$bool = this.regexAccept(String.raw`(?:f[ií]or|br[eé]ag)`, $$dpth + 1, $$cr)) !== null
                 ) {
-                    res = {kind: ASTKinds.Bool, bool};
+                    $$res = {kind: ASTKinds.Bool, bool: $scope$bool};
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchNeamhni($$dpth: number, cr?: ContextRecorder): Nullable<Neamhni> {
+    public matchNeamhni($$dpth: number, $$cr?: ContextRecorder): Nullable<Neamhni> {
         return this.runner<Neamhni>($$dpth,
             (log) => {
                 if (log) {
                     log("Neamhni");
                 }
-                let res: Nullable<Neamhni> = null;
+                let $$res: Nullable<Neamhni> = null;
                 if (true
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.regexAccept(String.raw`(?:neamhn[ií])`, $$dpth + 1, cr) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.regexAccept(String.raw`(?:neamhn[ií])`, $$dpth + 1, $$cr) !== null
                 ) {
-                    res = {kind: ASTKinds.Neamhni, };
+                    $$res = {kind: ASTKinds.Neamhni, };
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchInt($$dpth: number, cr?: ContextRecorder): Nullable<Int> {
+    public matchInt($$dpth: number, $$cr?: ContextRecorder): Nullable<Int> {
         return this.runner<Int>($$dpth,
             (log) => {
                 if (log) {
                     log("Int");
                 }
-                let int: Nullable<string>;
-                let res: Nullable<Int> = null;
+                let $scope$int: Nullable<string>;
+                let $$res: Nullable<Int> = null;
                 if (true
-                    && this.match_($$dpth + 1, cr) !== null
-                    && (int = this.regexAccept(String.raw`(?:-?[0-9]+(?:\.[0-9]+)?)`, $$dpth + 1, cr)) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && ($scope$int = this.regexAccept(String.raw`(?:-?[0-9]+(?:\.[0-9]+)?)`, $$dpth + 1, $$cr)) !== null
                 ) {
-                    res = {kind: ASTKinds.Int, int};
+                    $$res = {kind: ASTKinds.Int, int: $scope$int};
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public matchLitreacha($$dpth: number, cr?: ContextRecorder): Nullable<Litreacha> {
+    public matchLitreacha($$dpth: number, $$cr?: ContextRecorder): Nullable<Litreacha> {
         return this.runner<Litreacha>($$dpth,
             (log) => {
                 if (log) {
                     log("Litreacha");
                 }
-                let val: Nullable<string>;
-                let res: Nullable<Litreacha> = null;
+                let $scope$val: Nullable<string>;
+                let $$res: Nullable<Litreacha> = null;
                 if (true
-                    && this.match_($$dpth + 1, cr) !== null
-                    && this.regexAccept(String.raw`(?:\')`, $$dpth + 1, cr) !== null
-                    && (val = this.regexAccept(String.raw`(?:([^\'\\]|\\.)*)`, $$dpth + 1, cr)) !== null
-                    && this.regexAccept(String.raw`(?:\')`, $$dpth + 1, cr) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.regexAccept(String.raw`(?:\')`, $$dpth + 1, $$cr) !== null
+                    && ($scope$val = this.regexAccept(String.raw`(?:([^\'\\]|\\.)*)`, $$dpth + 1, $$cr)) !== null
+                    && this.regexAccept(String.raw`(?:\')`, $$dpth + 1, $$cr) !== null
                 ) {
-                    res = {kind: ASTKinds.Litreacha, val};
+                    $$res = {kind: ASTKinds.Litreacha, val: $scope$val};
                 }
-                return res;
-            }, cr)();
+                return $$res;
+            }, $$cr)();
     }
-    public match_($$dpth: number, cr?: ContextRecorder): Nullable<_> {
-        return this.loop<wspace>(() => this.matchwspace($$dpth + 1, cr), true);
+    public match_($$dpth: number, $$cr?: ContextRecorder): Nullable<_> {
+        return this.loop<wspace>(() => this.matchwspace($$dpth + 1, $$cr), true);
     }
-    public matchwspace($$dpth: number, cr?: ContextRecorder): Nullable<wspace> {
-        return this.regexAccept(String.raw`(?:(?:\s|>--(?:(?!--<).)*(--<|\n|$)))`, $$dpth + 1, cr);
+    public matchwspace($$dpth: number, $$cr?: ContextRecorder): Nullable<wspace> {
+        return this.regexAccept(String.raw`(?:(?:\s|>--(?:(?!--<).)*(--<|\n|$)))`, $$dpth + 1, $$cr);
     }
-    public matchgap($$dpth: number, cr?: ContextRecorder): Nullable<gap> {
+    public matchgap($$dpth: number, $$cr?: ContextRecorder): Nullable<gap> {
         return this.choice<gap>([
-            () => this.matchgap_1($$dpth + 1, cr),
-            () => this.matchgap_2($$dpth + 1, cr),
+            () => this.matchgap_1($$dpth + 1, $$cr),
+            () => this.matchgap_2($$dpth + 1, $$cr),
         ]);
     }
-    public matchgap_1($$dpth: number, cr?: ContextRecorder): Nullable<gap_1> {
-        return this.loop<gap_$0>(() => this.matchgap_$0($$dpth + 1, cr), false);
+    public matchgap_1($$dpth: number, $$cr?: ContextRecorder): Nullable<gap_1> {
+        return this.loop<gap_$0>(() => this.matchgap_$0($$dpth + 1, $$cr), false);
     }
-    public matchgap_2($$dpth: number, cr?: ContextRecorder): Nullable<gap_2> {
-        return this.regexAccept(String.raw`(?:$)`, $$dpth + 1, cr);
+    public matchgap_2($$dpth: number, $$cr?: ContextRecorder): Nullable<gap_2> {
+        return this.regexAccept(String.raw`(?:$)`, $$dpth + 1, $$cr);
     }
-    public matchgap_$0($$dpth: number, cr?: ContextRecorder): Nullable<gap_$0> {
+    public matchgap_$0($$dpth: number, $$cr?: ContextRecorder): Nullable<gap_$0> {
         return this.choice<gap_$0>([
-            () => this.matchgap_$0_1($$dpth + 1, cr),
-            () => this.matchgap_$0_2($$dpth + 1, cr),
+            () => this.matchgap_$0_1($$dpth + 1, $$cr),
+            () => this.matchgap_$0_2($$dpth + 1, $$cr),
         ]);
     }
-    public matchgap_$0_1($$dpth: number, cr?: ContextRecorder): Nullable<gap_$0_1> {
-        return this.matchwspace($$dpth + 1, cr);
+    public matchgap_$0_1($$dpth: number, $$cr?: ContextRecorder): Nullable<gap_$0_1> {
+        return this.matchwspace($$dpth + 1, $$cr);
     }
-    public matchgap_$0_2($$dpth: number, cr?: ContextRecorder): Nullable<gap_$0_2> {
-        return this.regexAccept(String.raw`(?:[^a-zA-Z0-9áéíóúÁÉÍÓÚ])`, $$dpth + 1, cr);
+    public matchgap_$0_2($$dpth: number, $$cr?: ContextRecorder): Nullable<gap_$0_2> {
+        return this.regexAccept(String.raw`(?:[^a-zA-Z0-9áéíóúÁÉÍÓÚ])`, $$dpth + 1, $$cr);
     }
-    public matchPlusMinus($$dpth: number, cr?: ContextRecorder): Nullable<PlusMinus> {
-        return this.regexAccept(String.raw`(?:\+|-)`, $$dpth + 1, cr);
+    public matchPlusMinus($$dpth: number, $$cr?: ContextRecorder): Nullable<PlusMinus> {
+        return this.regexAccept(String.raw`(?:\+|-)`, $$dpth + 1, $$cr);
     }
-    public matchAsgnOp($$dpth: number, cr?: ContextRecorder): Nullable<AsgnOp> {
-        return this.regexAccept(String.raw`(?:=|\+=|\*=|-=|%=|\/=)`, $$dpth + 1, cr);
+    public matchAsgnOp($$dpth: number, $$cr?: ContextRecorder): Nullable<AsgnOp> {
+        return this.regexAccept(String.raw`(?:=|\+=|\*=|-=|%=|\/=)`, $$dpth + 1, $$cr);
     }
-    public matchMulDiv($$dpth: number, cr?: ContextRecorder): Nullable<MulDiv> {
-        return this.regexAccept(String.raw`(?:\*|\/\/|%|\/)`, $$dpth + 1, cr);
+    public matchMulDiv($$dpth: number, $$cr?: ContextRecorder): Nullable<MulDiv> {
+        return this.regexAccept(String.raw`(?:\*|\/\/|%|\/)`, $$dpth + 1, $$cr);
     }
-    public matchCompare($$dpth: number, cr?: ContextRecorder): Nullable<Compare> {
-        return this.regexAccept(String.raw`(?:<=|>=|<|>)`, $$dpth + 1, cr);
+    public matchCompare($$dpth: number, $$cr?: ContextRecorder): Nullable<Compare> {
+        return this.regexAccept(String.raw`(?:<=|>=|<|>)`, $$dpth + 1, $$cr);
     }
-    public matchKeyword($$dpth: number, cr?: ContextRecorder): Nullable<Keyword> {
+    public matchKeyword($$dpth: number, $$cr?: ContextRecorder): Nullable<Keyword> {
         return this.choice<Keyword>([
-            () => this.matchKeyword_1($$dpth + 1, cr),
-            () => this.matchKeyword_2($$dpth + 1, cr),
-            () => this.matchKeyword_3($$dpth + 1, cr),
-            () => this.matchKeyword_4($$dpth + 1, cr),
-            () => this.matchKeyword_5($$dpth + 1, cr),
-            () => this.matchKeyword_6($$dpth + 1, cr),
-            () => this.matchKeyword_7($$dpth + 1, cr),
-            () => this.matchKeyword_8($$dpth + 1, cr),
-            () => this.matchKeyword_9($$dpth + 1, cr),
+            () => this.matchKeyword_1($$dpth + 1, $$cr),
+            () => this.matchKeyword_2($$dpth + 1, $$cr),
+            () => this.matchKeyword_3($$dpth + 1, $$cr),
+            () => this.matchKeyword_4($$dpth + 1, $$cr),
+            () => this.matchKeyword_5($$dpth + 1, $$cr),
+            () => this.matchKeyword_6($$dpth + 1, $$cr),
+            () => this.matchKeyword_7($$dpth + 1, $$cr),
+            () => this.matchKeyword_8($$dpth + 1, $$cr),
+            () => this.matchKeyword_9($$dpth + 1, $$cr),
         ]);
     }
-    public matchKeyword_1($$dpth: number, cr?: ContextRecorder): Nullable<Keyword_1> {
-        return this.regexAccept(String.raw`(?:m[áa])`, $$dpth + 1, cr);
+    public matchKeyword_1($$dpth: number, $$cr?: ContextRecorder): Nullable<Keyword_1> {
+        return this.regexAccept(String.raw`(?:m[áa])`, $$dpth + 1, $$cr);
     }
-    public matchKeyword_2($$dpth: number, cr?: ContextRecorder): Nullable<Keyword_2> {
-        return this.regexAccept(String.raw`(?:n[oó])`, $$dpth + 1, cr);
+    public matchKeyword_2($$dpth: number, $$cr?: ContextRecorder): Nullable<Keyword_2> {
+        return this.regexAccept(String.raw`(?:n[oó])`, $$dpth + 1, $$cr);
     }
-    public matchKeyword_3($$dpth: number, cr?: ContextRecorder): Nullable<Keyword_3> {
-        return this.regexAccept(String.raw`(?:nuair-a)`, $$dpth + 1, cr);
+    public matchKeyword_3($$dpth: number, $$cr?: ContextRecorder): Nullable<Keyword_3> {
+        return this.regexAccept(String.raw`(?:nuair-a)`, $$dpth + 1, $$cr);
     }
-    public matchKeyword_4($$dpth: number, cr?: ContextRecorder): Nullable<Keyword_4> {
-        return this.regexAccept(String.raw`(?:f[ií]or|br[eé]ag)`, $$dpth + 1, cr);
+    public matchKeyword_4($$dpth: number, $$cr?: ContextRecorder): Nullable<Keyword_4> {
+        return this.regexAccept(String.raw`(?:f[ií]or|br[eé]ag)`, $$dpth + 1, $$cr);
     }
-    public matchKeyword_5($$dpth: number, cr?: ContextRecorder): Nullable<Keyword_5> {
-        return this.regexAccept(String.raw`(?:gn[ií]omh)`, $$dpth + 1, cr);
+    public matchKeyword_5($$dpth: number, $$cr?: ContextRecorder): Nullable<Keyword_5> {
+        return this.regexAccept(String.raw`(?:gn[ií]omh)`, $$dpth + 1, $$cr);
     }
-    public matchKeyword_6($$dpth: number, cr?: ContextRecorder): Nullable<Keyword_6> {
-        return this.regexAccept(String.raw`(?:chun-cinn)`, $$dpth + 1, cr);
+    public matchKeyword_6($$dpth: number, $$cr?: ContextRecorder): Nullable<Keyword_6> {
+        return this.regexAccept(String.raw`(?:chun-cinn)`, $$dpth + 1, $$cr);
     }
-    public matchKeyword_7($$dpth: number, cr?: ContextRecorder): Nullable<Keyword_7> {
-        return this.regexAccept(String.raw`(?:neamhn[ií])`, $$dpth + 1, cr);
+    public matchKeyword_7($$dpth: number, $$cr?: ContextRecorder): Nullable<Keyword_7> {
+        return this.regexAccept(String.raw`(?:neamhn[ií])`, $$dpth + 1, $$cr);
     }
-    public matchKeyword_8($$dpth: number, cr?: ContextRecorder): Nullable<Keyword_8> {
-        return this.regexAccept(String.raw`(?:toradh)`, $$dpth + 1, cr);
+    public matchKeyword_8($$dpth: number, $$cr?: ContextRecorder): Nullable<Keyword_8> {
+        return this.regexAccept(String.raw`(?:toradh)`, $$dpth + 1, $$cr);
     }
-    public matchKeyword_9($$dpth: number, cr?: ContextRecorder): Nullable<Keyword_9> {
-        return this.regexAccept(String.raw`(?:creatlach)`, $$dpth + 1, cr);
+    public matchKeyword_9($$dpth: number, $$cr?: ContextRecorder): Nullable<Keyword_9> {
+        return this.regexAccept(String.raw`(?:creatlach)`, $$dpth + 1, $$cr);
     }
     public test(): boolean {
         const mrk = this.mark();


### PR DESCRIPTION
Add scoping prefixes to variables created to avoid namespace collisions.
Add tests to avoid.

closes #5 