### PR TITLE
Export ASTNodeIntf interface.

### DIFF
--- a/demos/calculator/parser.ts
+++ b/demos/calculator/parser.ts
@@ -7,347 +7,363 @@
 * _    := '\s*'
 */
 type Nullable<T> = T | null;
-type $$RuleType<T> = (log? : (msg : string) => void) => Nullable<T>;
-export interface ContextRecorder {
-    record(pos: PosInfo, depth : number, result: any, negating : boolean, extraInfo : string[]) : void;
-}
-interface ASTNodeIntf {
+type $$RuleType<T> = () => Nullable<T>;
+export interface ASTNodeIntf {
     kind: ASTKinds;
 }
 export enum ASTKinds {
-    SUM,
-    SUM_$0,
-    FAC,
-    FAC_$0,
-    ATOM_1,
-    ATOM_2,
-    INT,
-    _,
+    SUM = "SUM",
+    SUM_$0 = "SUM_$0",
+    FAC = "FAC",
+    FAC_$0 = "FAC_$0",
+    ATOM_1 = "ATOM_1",
+    ATOM_2 = "ATOM_2",
+    INT = "INT",
+    _ = "_",
 }
 export interface SUM {
-    kind : ASTKinds.SUM;
-    head : FAC;
-    tail : SUM_$0[];
+    kind: ASTKinds.SUM;
+    head: FAC;
+    tail: SUM_$0[];
 }
 export interface SUM_$0 {
-    kind : ASTKinds.SUM_$0;
-    op : string;
-    sm : FAC;
+    kind: ASTKinds.SUM_$0;
+    op: string;
+    sm: FAC;
 }
 export interface FAC {
-    kind : ASTKinds.FAC;
-    head : ATOM;
-    tail : FAC_$0[];
+    kind: ASTKinds.FAC;
+    head: ATOM;
+    tail: FAC_$0[];
 }
 export interface FAC_$0 {
-    kind : ASTKinds.FAC_$0;
-    op : string;
-    sm : ATOM;
+    kind: ASTKinds.FAC_$0;
+    op: string;
+    sm: ATOM;
 }
 export type ATOM = ATOM_1 | ATOM_2;
 export interface ATOM_1 {
-    kind : ASTKinds.ATOM_1;
-    val : INT;
+    kind: ASTKinds.ATOM_1;
+    val: INT;
 }
 export interface ATOM_2 {
-    kind : ASTKinds.ATOM_2;
-    val : SUM;
+    kind: ASTKinds.ATOM_2;
+    val: SUM;
 }
 export interface INT {
-    kind : ASTKinds.INT;
-    val : string;
+    kind: ASTKinds.INT;
+    val: string;
 }
 export type _ = string;
 export class Parser {
-    private pos : PosInfo;
-    readonly input : string;
+    private readonly input: string;
+    private pos: PosInfo;
     private negating: boolean = false;
-    constructor(input : string) {
-        this.pos = new PosInfo(0, 1, 0);
+    private memoSafe: boolean = true;
+    constructor(input: string) {
+        this.pos = {overallPos: 0, line: 1, offset: 0};
         this.input = input;
     }
-    private mark() : PosInfo {
-        return this.pos;
-    }
-    reset(pos : PosInfo) {
+    public reset(pos: PosInfo) {
         this.pos = pos;
     }
-    finished() : boolean {
-        return this.pos.overall_pos === this.input.length;
+    public finished(): boolean {
+        return this.pos.overallPos === this.input.length;
     }
-    private loop<T>(func : $$RuleType<T>, star : boolean = false) : Nullable<T[]> {
+    public clearMemos(): void {
+    }
+    public matchSUM($$dpth: number, $$cr?: ErrorTracker): Nullable<SUM> {
+        return this.run<SUM>($$dpth,
+            () => {
+                let $scope$head: Nullable<FAC>;
+                let $scope$tail: Nullable<SUM_$0[]>;
+                let $$res: Nullable<SUM> = null;
+                if (true
+                    && ($scope$head = this.matchFAC($$dpth + 1, $$cr)) !== null
+                    && ($scope$tail = this.loop<SUM_$0>(() => this.matchSUM_$0($$dpth + 1, $$cr), true)) !== null
+                ) {
+                    $$res = {kind: ASTKinds.SUM, head: $scope$head, tail: $scope$tail};
+                }
+                return $$res;
+            });
+    }
+    public matchSUM_$0($$dpth: number, $$cr?: ErrorTracker): Nullable<SUM_$0> {
+        return this.run<SUM_$0>($$dpth,
+            () => {
+                let $scope$op: Nullable<string>;
+                let $scope$sm: Nullable<FAC>;
+                let $$res: Nullable<SUM_$0> = null;
+                if (true
+                    && ($scope$op = this.regexAccept(String.raw`(?:\+|-)`, $$dpth + 1, $$cr)) !== null
+                    && ($scope$sm = this.matchFAC($$dpth + 1, $$cr)) !== null
+                ) {
+                    $$res = {kind: ASTKinds.SUM_$0, op: $scope$op, sm: $scope$sm};
+                }
+                return $$res;
+            });
+    }
+    public matchFAC($$dpth: number, $$cr?: ErrorTracker): Nullable<FAC> {
+        return this.run<FAC>($$dpth,
+            () => {
+                let $scope$head: Nullable<ATOM>;
+                let $scope$tail: Nullable<FAC_$0[]>;
+                let $$res: Nullable<FAC> = null;
+                if (true
+                    && ($scope$head = this.matchATOM($$dpth + 1, $$cr)) !== null
+                    && ($scope$tail = this.loop<FAC_$0>(() => this.matchFAC_$0($$dpth + 1, $$cr), true)) !== null
+                ) {
+                    $$res = {kind: ASTKinds.FAC, head: $scope$head, tail: $scope$tail};
+                }
+                return $$res;
+            });
+    }
+    public matchFAC_$0($$dpth: number, $$cr?: ErrorTracker): Nullable<FAC_$0> {
+        return this.run<FAC_$0>($$dpth,
+            () => {
+                let $scope$op: Nullable<string>;
+                let $scope$sm: Nullable<ATOM>;
+                let $$res: Nullable<FAC_$0> = null;
+                if (true
+                    && ($scope$op = this.regexAccept(String.raw`(?:\*|/)`, $$dpth + 1, $$cr)) !== null
+                    && ($scope$sm = this.matchATOM($$dpth + 1, $$cr)) !== null
+                ) {
+                    $$res = {kind: ASTKinds.FAC_$0, op: $scope$op, sm: $scope$sm};
+                }
+                return $$res;
+            });
+    }
+    public matchATOM($$dpth: number, $$cr?: ErrorTracker): Nullable<ATOM> {
+        return this.choice<ATOM>([
+            () => this.matchATOM_1($$dpth + 1, $$cr),
+            () => this.matchATOM_2($$dpth + 1, $$cr),
+        ]);
+    }
+    public matchATOM_1($$dpth: number, $$cr?: ErrorTracker): Nullable<ATOM_1> {
+        return this.run<ATOM_1>($$dpth,
+            () => {
+                let $scope$val: Nullable<INT>;
+                let $$res: Nullable<ATOM_1> = null;
+                if (true
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && ($scope$val = this.matchINT($$dpth + 1, $$cr)) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                ) {
+                    $$res = {kind: ASTKinds.ATOM_1, val: $scope$val};
+                }
+                return $$res;
+            });
+    }
+    public matchATOM_2($$dpth: number, $$cr?: ErrorTracker): Nullable<ATOM_2> {
+        return this.run<ATOM_2>($$dpth,
+            () => {
+                let $scope$val: Nullable<SUM>;
+                let $$res: Nullable<ATOM_2> = null;
+                if (true
+                    && this.match_($$dpth + 1, $$cr) !== null
+                    && this.regexAccept(String.raw`(?:\()`, $$dpth + 1, $$cr) !== null
+                    && ($scope$val = this.matchSUM($$dpth + 1, $$cr)) !== null
+                    && this.regexAccept(String.raw`(?:\))`, $$dpth + 1, $$cr) !== null
+                    && this.match_($$dpth + 1, $$cr) !== null
+                ) {
+                    $$res = {kind: ASTKinds.ATOM_2, val: $scope$val};
+                }
+                return $$res;
+            });
+    }
+    public matchINT($$dpth: number, $$cr?: ErrorTracker): Nullable<INT> {
+        return this.run<INT>($$dpth,
+            () => {
+                let $scope$val: Nullable<string>;
+                let $$res: Nullable<INT> = null;
+                if (true
+                    && ($scope$val = this.regexAccept(String.raw`(?:[0-9]+)`, $$dpth + 1, $$cr)) !== null
+                ) {
+                    $$res = {kind: ASTKinds.INT, val: $scope$val};
+                }
+                return $$res;
+            });
+    }
+    public match_($$dpth: number, $$cr?: ErrorTracker): Nullable<_> {
+        return this.regexAccept(String.raw`(?:\s*)`, $$dpth + 1, $$cr);
+    }
+    public test(): boolean {
         const mrk = this.mark();
-        let res : T[] = [];
-        for(;;) {
+        const res = this.matchSUM(0);
+        const ans = res !== null;
+        this.reset(mrk);
+        return ans;
+    }
+    public parse(): ParseResult {
+        const mrk = this.mark();
+        const res = this.matchSUM(0);
+        if (res)
+            return {ast: res, errs: []};
+        this.reset(mrk);
+        const rec = new ErrorTracker();
+        this.clearMemos();
+        this.matchSUM(0, rec);
+        const err = rec.getErr()
+        return {ast: res, errs: err !== null ? [err] : []}
+    }
+    public mark(): PosInfo {
+        return this.pos;
+    }
+    private loop<T>(func: $$RuleType<T>, star: boolean = false): Nullable<T[]> {
+        const mrk = this.mark();
+        const res: T[] = [];
+        for (;;) {
             const t = func();
-            if(!t)
+            if (t === null) {
                 break;
+            }
             res.push(t);
         }
-        if(star || res.length > 0)
+        if (star || res.length > 0) {
+            return res;
+        }
+        this.reset(mrk);
+        return null;
+    }
+    private run<T>($$dpth: number, fn: $$RuleType<T>): Nullable<T> {
+        const mrk = this.mark();
+        const res = fn()
+        if (res !== null)
             return res;
         this.reset(mrk);
         return null;
     }
-    private runner<T>($$dpth : number, fn : $$RuleType<T>,
-        cr? : ContextRecorder) : $$RuleType<T> {
-        return () => {
-            const mrk = this.mark();
-            const res = cr ? (()=>{
-                let extraInfo : string[] = [];
-                const res = fn((msg : string) => extraInfo.push(msg));
-                cr.record(mrk, $$dpth, res, this.negating, extraInfo);
-                return res;
-            })() : fn();
-            if(res !== null)
-                return res;
-            this.reset(mrk);
-            return null
-        }
-    }
-    private choice<T>(fns : $$RuleType<T>[]) : Nullable<T> {
-        for(let f of fns){
+    private choice<T>(fns: Array<$$RuleType<T>>): Nullable<T> {
+        for (const f of fns) {
             const res = f();
-            if(res)
+            if (res !== null) {
                 return res;
+            }
         }
         return null;
     }
-    private regexAccept(match : string, dpth : number, cr? : ContextRecorder) : Nullable<string> {
-        return this.runner<string>(dpth,
-            (log) => {
-                if(log){
-                    if(this.negating)
-                        log('$$!StrMatch');
-                    else
-                        log('$$StrMatch');
-                    log(match);
+    private regexAccept(match: string, dpth: number, cr?: ErrorTracker): Nullable<string> {
+        return this.run<string>(dpth,
+            () => {
+                const reg = new RegExp(match, "y");
+                const mrk = this.mark();
+                reg.lastIndex = mrk.overallPos;
+                const res = this.tryConsume(reg);
+                if(cr) {
+                    cr.record(mrk, res, {
+                        kind: "RegexMatch",
+                        // We substring from 3 to len - 1 to strip off the
+                        // non-capture group syntax added as a WebKit workaround
+                        literal: match.substring(3, match.length - 1),
+                        negated: this.negating,
+                    });
                 }
-                var reg = new RegExp(match, 'y');
-                reg.lastIndex = this.mark().overall_pos;
-                const res = reg.exec(this.input);
-                if(res){
-                    let lineJmp = 0;
-                    let lind = -1;
-                    for(let i = 0; i < res[0].length; ++i){
-                        if(res[0][i] === '\n'){
-                            ++lineJmp;
-                            lind = i;
-                        }
-                    }
-                    this.pos = new PosInfo(reg.lastIndex, this.pos.line + lineJmp, lind === -1 ? this.pos.offset + res[0].length: (res[0].length - lind));
-                    return res[0];
-                }
-                return null;
-            }, cr)();
+                return res;
+            });
     }
-    private noConsume<T>(fn : $$RuleType<T>) : Nullable<T> {
+    private tryConsume(reg: RegExp): Nullable<string> {
+        const res = reg.exec(this.input);
+        if (res) {
+            let lineJmp = 0;
+            let lind = -1;
+            for (let i = 0; i < res[0].length; ++i) {
+                if (res[0][i] === "\n") {
+                    ++lineJmp;
+                    lind = i;
+                }
+            }
+            this.pos = {
+                overallPos: reg.lastIndex,
+                line: this.pos.line + lineJmp,
+                offset: lind === -1 ? this.pos.offset + res[0].length : (res[0].length - lind - 1)
+            };
+            return res[0];
+        }
+        return null;
+    }
+    private noConsume<T>(fn: $$RuleType<T>): Nullable<T> {
         const mrk = this.mark();
         const res = fn();
         this.reset(mrk);
         return res;
     }
-    private negate<T>(fn : $$RuleType<T>) : Nullable<boolean> {
+    private negate<T>(fn: $$RuleType<T>): Nullable<boolean> {
         const mrk = this.mark();
         const oneg = this.negating;
-        this.negating = !oneg
+        this.negating = !oneg;
         const res = fn();
         this.negating = oneg;
         this.reset(mrk);
         return res === null ? true : null;
     }
-    matchSUM($$dpth : number, cr? : ContextRecorder) : Nullable<SUM> {
-        return this.runner<SUM>($$dpth,
-            (log) => {
-                if(log)
-                    log('SUM');
-                let head : Nullable<FAC>;
-                let tail : Nullable<SUM_$0[]>;
-                let res : Nullable<SUM> = null;
-                if(true
-                    && (head = this.matchFAC($$dpth + 1, cr)) != null
-                    && (tail = this.loop<SUM_$0>(()=> this.matchSUM_$0($$dpth + 1, cr), true)) != null
-                )
-                    res = {kind: ASTKinds.SUM, head : head, tail : tail};
-                return res;
-            }, cr)();
-    }
-    matchSUM_$0($$dpth : number, cr? : ContextRecorder) : Nullable<SUM_$0> {
-        return this.runner<SUM_$0>($$dpth,
-            (log) => {
-                if(log)
-                    log('SUM_$0');
-                let op : Nullable<string>;
-                let sm : Nullable<FAC>;
-                let res : Nullable<SUM_$0> = null;
-                if(true
-                    && (op = this.regexAccept(String.raw`\+|-`, $$dpth+1, cr)) != null
-                    && (sm = this.matchFAC($$dpth + 1, cr)) != null
-                )
-                    res = {kind: ASTKinds.SUM_$0, op : op, sm : sm};
-                return res;
-            }, cr)();
-    }
-    matchFAC($$dpth : number, cr? : ContextRecorder) : Nullable<FAC> {
-        return this.runner<FAC>($$dpth,
-            (log) => {
-                if(log)
-                    log('FAC');
-                let head : Nullable<ATOM>;
-                let tail : Nullable<FAC_$0[]>;
-                let res : Nullable<FAC> = null;
-                if(true
-                    && (head = this.matchATOM($$dpth + 1, cr)) != null
-                    && (tail = this.loop<FAC_$0>(()=> this.matchFAC_$0($$dpth + 1, cr), true)) != null
-                )
-                    res = {kind: ASTKinds.FAC, head : head, tail : tail};
-                return res;
-            }, cr)();
-    }
-    matchFAC_$0($$dpth : number, cr? : ContextRecorder) : Nullable<FAC_$0> {
-        return this.runner<FAC_$0>($$dpth,
-            (log) => {
-                if(log)
-                    log('FAC_$0');
-                let op : Nullable<string>;
-                let sm : Nullable<ATOM>;
-                let res : Nullable<FAC_$0> = null;
-                if(true
-                    && (op = this.regexAccept(String.raw`\*|/`, $$dpth+1, cr)) != null
-                    && (sm = this.matchATOM($$dpth + 1, cr)) != null
-                )
-                    res = {kind: ASTKinds.FAC_$0, op : op, sm : sm};
-                return res;
-            }, cr)();
-    }
-    matchATOM($$dpth : number, cr? : ContextRecorder) : Nullable<ATOM> {
-        return this.choice<ATOM>([
-            () => { return this.matchATOM_1($$dpth + 1, cr) },
-            () => { return this.matchATOM_2($$dpth + 1, cr) },
-        ]);
-    }
-    matchATOM_1($$dpth : number, cr? : ContextRecorder) : Nullable<ATOM_1> {
-        return this.runner<ATOM_1>($$dpth,
-            (log) => {
-                if(log)
-                    log('ATOM_1');
-                let val : Nullable<INT>;
-                let res : Nullable<ATOM_1> = null;
-                if(true
-                    && this.match_($$dpth + 1, cr) != null
-                    && (val = this.matchINT($$dpth + 1, cr)) != null
-                    && this.match_($$dpth + 1, cr) != null
-                )
-                    res = {kind: ASTKinds.ATOM_1, val : val};
-                return res;
-            }, cr)();
-    }
-    matchATOM_2($$dpth : number, cr? : ContextRecorder) : Nullable<ATOM_2> {
-        return this.runner<ATOM_2>($$dpth,
-            (log) => {
-                if(log)
-                    log('ATOM_2');
-                let val : Nullable<SUM>;
-                let res : Nullable<ATOM_2> = null;
-                if(true
-                    && this.match_($$dpth + 1, cr) != null
-                    && this.regexAccept(String.raw`\(`, $$dpth+1, cr) != null
-                    && (val = this.matchSUM($$dpth + 1, cr)) != null
-                    && this.regexAccept(String.raw`\)`, $$dpth+1, cr) != null
-                    && this.match_($$dpth + 1, cr) != null
-                )
-                    res = {kind: ASTKinds.ATOM_2, val : val};
-                return res;
-            }, cr)();
-    }
-    matchINT($$dpth : number, cr? : ContextRecorder) : Nullable<INT> {
-        return this.runner<INT>($$dpth,
-            (log) => {
-                if(log)
-                    log('INT');
-                let val : Nullable<string>;
-                let res : Nullable<INT> = null;
-                if(true
-                    && (val = this.regexAccept(String.raw`[0-9]+`, $$dpth+1, cr)) != null
-                )
-                    res = {kind: ASTKinds.INT, val : val};
-                return res;
-            }, cr)();
-    }
-    match_($$dpth : number, cr? : ContextRecorder) : Nullable<_> {
-        return this.regexAccept(String.raw`\s*`, $$dpth+1, cr);
-    }
-    parse() : ParseResult {
-        const mrk = this.mark();
-        const res = this.matchSUM(0);
-        if(res && this.finished())
-            return new ParseResult(res, null);
-        this.reset(mrk);
-        const rec = new ErrorTracker();
-        this.matchSUM(0, rec);
-        return new ParseResult(res, rec.getErr());
+    private memoise<K>(rule: $$RuleType<K>, memo: Map<number, [Nullable<K>, PosInfo]>): Nullable<K> {
+        const $scope$pos = this.mark();
+        const $scope$memoRes = memo.get($scope$pos.overallPos);
+        if(this.memoSafe && $scope$memoRes !== undefined) {
+        this.reset($scope$memoRes[1]);
+        return $scope$memoRes[0];
+        }
+        const $scope$result = rule();
+        if(this.memoSafe)
+        memo.set($scope$pos.overallPos, [$scope$result, this.mark()]);
+        return $scope$result;
     }
 }
-export class ParseResult {
-    ast : Nullable<SUM>;
-    err : Nullable<SyntaxErr>;
-    constructor(ast : Nullable<SUM>, err : Nullable<SyntaxErr>){
-        this.ast = ast;
-        this.err = err;
-    }
+export function parse(s: string): ParseResult {
+    const p = new Parser(s);
+    return p.parse();
 }
-export class PosInfo {
-    overall_pos : number;
-    line : number;
-    offset : number;
-    constructor(overall_pos : number, line : number, offset : number) {
-        this.overall_pos = overall_pos;
-        this.line = line;
-        this.offset = offset;
-    }
+export interface ParseResult {
+    ast: Nullable<SUM>;
+    errs: SyntaxErr[];
 }
+export interface PosInfo {
+    readonly overallPos: number;
+    readonly line: number;
+    readonly offset: number;
+}
+export interface RegexMatch {
+    readonly kind: "RegexMatch";
+    readonly negated: boolean;
+    readonly literal: string;
+}
+export type EOFMatch = { kind: "EOF"; negated: boolean };
+export type MatchAttempt = RegexMatch | EOFMatch;
 export class SyntaxErr {
-    pos : PosInfo;
-    exprules : string[];
-    expmatches : string[]
-    constructor(pos : PosInfo, exprules : Set<string>, expmatches : Set<string>){
+    public pos: PosInfo;
+    public expmatches: MatchAttempt[];
+    constructor(pos: PosInfo, expmatches: MatchAttempt[]) {
         this.pos = pos;
-        this.exprules = [...exprules];
         this.expmatches = [...expmatches];
     }
-    toString() : string {
-        return `Syntax Error at line ${this.pos.line}:${this.pos.offset}. Tried to match rules ${this.exprules.join(', ')}. Expected one of ${this.expmatches.map(x => ` '${x}'`)}`;
+    public toString(): string {
+        return `Syntax Error at line ${this.pos.line}:${this.pos.offset}. Expected one of ${this.expmatches.map(x => x.kind === "EOF" ? " EOF" : ` ${x.negated ? 'not ': ''}'${x.literal}'`)}`;
     }
 }
-class ErrorTracker implements ContextRecorder {
-    mxpos : PosInfo = new PosInfo(-1, -1, -1)
-    mnd : number = -1;
-    prules : Set<string> = new Set();
-    pmatches: Set<string> = new Set();
-    record(pos : PosInfo, depth : number, result : any, negating : boolean, extraInfo : string[]){
-        if((result === null) === negating)
+class ErrorTracker {
+    private mxpos: PosInfo = {overallPos: -1, line: -1, offset: -1};
+    private regexset: Set<string> = new Set();
+    private pmatches: MatchAttempt[] = [];
+    public record(pos: PosInfo, result: any, att: MatchAttempt) {
+        if ((result === null) === att.negated)
             return;
-        if(pos.overall_pos > this.mxpos.overall_pos){
+        if (pos.overallPos > this.mxpos.overallPos) {
             this.mxpos = pos;
-            this.mnd = depth;
-            this.pmatches.clear();
-            this.prules.clear();
-        } else if(pos.overall_pos === this.mxpos.overall_pos && depth < this.mnd){
-            this.mnd = depth;
-            this.prules.clear();
+            this.pmatches = [];
+            this.regexset.clear()
         }
-        if(this.mxpos.overall_pos === pos.overall_pos && extraInfo.length >= 2) {
-            if(extraInfo[0] === '$$StrMatch')
-                this.pmatches.add(extraInfo[1]);
-            if(extraInfo[0] === '$$!StrMatch')
-                this.pmatches.add(`not ${extraInfo[1]}`);
+        if (this.mxpos.overallPos === pos.overallPos) {
+            if(att.kind === "RegexMatch") {
+                if(!this.regexset.has(att.literal))
+                    this.pmatches.push(att);
+                this.regexset.add(att.literal);
+            } else {
+                this.pmatches.push(att);
+            }
         }
-        if(this.mxpos.overall_pos === pos.overall_pos && this.mnd === depth)
-            extraInfo.forEach(x => { if(x !== '$$StrMatch' && x !== '$$!StrMatch') this.prules.add(x)});
     }
-    getErr() : SyntaxErr | null {
-        if(this.mxpos.overall_pos !== -1)
-            return new SyntaxErr(this.mxpos, this.prules, this.pmatches);
+    public getErr(): SyntaxErr | null {
+        if (this.mxpos.overallPos !== -1)
+            return new SyntaxErr(this.mxpos, this.pmatches);
         return null;
     }
 }

--- a/src/meta.ts
+++ b/src/meta.ts
@@ -70,7 +70,7 @@
 */
 type Nullable<T> = T | null;
 type $$RuleType<T> = () => Nullable<T>;
-interface ASTNodeIntf {
+export interface ASTNodeIntf {
     kind: ASTKinds;
 }
 export enum ASTKinds {

--- a/src/template.ts
+++ b/src/template.ts
@@ -22,7 +22,7 @@ export function expandTemplate(opts: TemplateOpts): Block {
     ...opts.header,
     "type Nullable<T> = T | null;",
     "type $$RuleType<T> = () => Nullable<T>;",
-    "interface ASTNodeIntf {",
+    "export interface ASTNodeIntf {",
     [
         "kind: ASTKinds;",
     ],

--- a/src/test/calc_leftrec_test/parser.ts
+++ b/src/test/calc_leftrec_test/parser.ts
@@ -21,7 +21,7 @@
 */
 type Nullable<T> = T | null;
 type $$RuleType<T> = () => Nullable<T>;
-interface ASTNodeIntf {
+export interface ASTNodeIntf {
     kind: ASTKinds;
 }
 export enum ASTKinds {

--- a/src/test/calc_test/parser.ts
+++ b/src/test/calc_test/parser.ts
@@ -22,7 +22,7 @@
 */
 type Nullable<T> = T | null;
 type $$RuleType<T> = () => Nullable<T>;
-interface ASTNodeIntf {
+export interface ASTNodeIntf {
     kind: ASTKinds;
 }
 export enum ASTKinds {

--- a/src/test/crlf_test/parser.ts
+++ b/src/test/crlf_test/parser.ts
@@ -29,7 +29,7 @@
 
 type Nullable<T> = T | null;
 type $$RuleType<T> = () => Nullable<T>;
-interface ASTNodeIntf {
+export interface ASTNodeIntf {
     kind: ASTKinds;
 }
 export enum ASTKinds {

--- a/src/test/eof_test/parser.ts
+++ b/src/test/eof_test/parser.ts
@@ -5,7 +5,7 @@
 */
 type Nullable<T> = T | null;
 type $$RuleType<T> = () => Nullable<T>;
-interface ASTNodeIntf {
+export interface ASTNodeIntf {
     kind: ASTKinds;
 }
 export enum ASTKinds {

--- a/src/test/id_test/parser.ts
+++ b/src/test/id_test/parser.ts
@@ -12,7 +12,7 @@
 */
 type Nullable<T> = T | null;
 type $$RuleType<T> = () => Nullable<T>;
-interface ASTNodeIntf {
+export interface ASTNodeIntf {
     kind: ASTKinds;
 }
 export enum ASTKinds {

--- a/src/test/indirect_leftrec_test/parser.ts
+++ b/src/test/indirect_leftrec_test/parser.ts
@@ -6,7 +6,7 @@
 */
 type Nullable<T> = T | null;
 type $$RuleType<T> = () => Nullable<T>;
-interface ASTNodeIntf {
+export interface ASTNodeIntf {
     kind: ASTKinds;
 }
 export enum ASTKinds {

--- a/src/test/memo_test/parser.ts
+++ b/src/test/memo_test/parser.ts
@@ -26,7 +26,7 @@
 */
 type Nullable<T> = T | null;
 type $$RuleType<T> = () => Nullable<T>;
-interface ASTNodeIntf {
+export interface ASTNodeIntf {
     kind: ASTKinds;
 }
 export enum ASTKinds {

--- a/src/test/memo_time_test/parser.ts
+++ b/src/test/memo_time_test/parser.ts
@@ -19,7 +19,7 @@
 */
 type Nullable<T> = T | null;
 type $$RuleType<T> = () => Nullable<T>;
-interface ASTNodeIntf {
+export interface ASTNodeIntf {
     kind: ASTKinds;
 }
 export enum ASTKinds {

--- a/src/test/muse/parser.ts
+++ b/src/test/muse/parser.ts
@@ -33,7 +33,7 @@
 */
 type Nullable<T> = T | null;
 type $$RuleType<T> = () => Nullable<T>;
-interface ASTNodeIntf {
+export interface ASTNodeIntf {
     kind: ASTKinds;
 }
 export enum ASTKinds {

--- a/src/test/pos_test/parser.ts
+++ b/src/test/pos_test/parser.ts
@@ -13,7 +13,7 @@
 
 type Nullable<T> = T | null;
 type $$RuleType<T> = () => Nullable<T>;
-interface ASTNodeIntf {
+export interface ASTNodeIntf {
     kind: ASTKinds;
 }
 export enum ASTKinds {

--- a/src/test/regex_flags_test/parser.ts
+++ b/src/test/regex_flags_test/parser.ts
@@ -4,7 +4,7 @@
 */
 type Nullable<T> = T | null;
 type $$RuleType<T> = () => Nullable<T>;
-interface ASTNodeIntf {
+export interface ASTNodeIntf {
     kind: ASTKinds;
 }
 export enum ASTKinds {

--- a/src/test/setanta_test/parser.ts
+++ b/src/test/setanta_test/parser.ts
@@ -173,7 +173,7 @@ type Acceptor = <T>(visitor: ASTVisitor<T>) => T;
 
 type Nullable<T> = T | null;
 type $$RuleType<T> = () => Nullable<T>;
-interface ASTNodeIntf {
+export interface ASTNodeIntf {
     kind: ASTKinds;
 }
 export enum ASTKinds {


### PR DESCRIPTION
That interface is not used internally but was not accessible outside the
generated code either. It is useful for code consuming arbitrary AST
nodes.

This change also regenerates the demos parsers, which haven't been
regenerated in a while - leading to a few extra diffs.