### PR TITLE
CLI: Create output directory if missing

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import * as fs from "fs";
+import path from "path";
 import * as yargs from "yargs";
 import { SyntaxErrs, buildParser } from "./gen";
 import { CheckError } from "./checks";
@@ -65,6 +66,7 @@ yargs.command("$0 <grammar> [output_file]", "Build parser from grammar",
             validateIncludeGrammarFlag(includeGrammar, inGram);
             const parser = buildParser(inGram, argv["num-enums"], argv["enable-memo"], regexFlags, includeGrammar);
             if(outputFile !== undefined) {
+                fs.mkdirSync(path.dirname(outputFile), { recursive: true });
                 fs.writeFileSync(outputFile, parser);
             } else {
                 process.stdout.write(parser);


### PR DESCRIPTION
Create output directory if missing. I use a `generated` folder for generated files which is in the gitignore and won't exist when somebody freshly clone the repo. E.g.:

> tspeg src/date/date-formula-parser.peg generated/date-formula-parser.ts